### PR TITLE
Tune block confirmation wait time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+The backend scaffolding includes a placeholder blockchain integration. Block
+confirmation wait time has been tuned to under two seconds for development
+purposes. See `backend/src/blockchain/blockchain_integration.ts`.

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,18 @@
 // blockchain_integration.ts - placeholder or stub for chai-vc-platform
+
+// Time (in milliseconds) to wait before considering a block confirmed.
+// This value is tuned to be less than two seconds in order to keep
+// interactions with the chain snappy in local development.
+export const BLOCK_CONFIRMATION_TARGET_MS = 1800;
+
+/**
+ * Wait for a block confirmation.
+ *
+ * In the actual implementation this would poll the blockchain for a
+ * confirmation event. Since this repository only contains scaffolding,
+ * the function simply waits for the configured confirmation time.
+ */
+export async function waitForBlockConfirmation(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, BLOCK_CONFIRMATION_TARGET_MS));
+}
+


### PR DESCRIPTION
## Summary
- document block confirmation wait time tuning in README
- set `BLOCK_CONFIRMATION_TARGET_MS` to 1800ms and add helper in blockchain integration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d2324a2e083208b36eccf565dfbc7