### PR TITLE
Add clinician DID generation utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Clinician Onboarding
+
+The backend includes lightweight utilities for generating and resolving
+clinician DIDs during onboarding. The `onboardClinician` helper in
+`backend/src/controllers/onboarding_controller.ts` creates a new DID for a
+clinician using a simple `did:example` scheme. The resulting DID document can be
+looked up later with `resolveClinician` which uses the placeholder resolver in
+`backend/src/blockchain/did_service.ts`.

--- a/backend/src/blockchain/did_service.ts
+++ b/backend/src/blockchain/did_service.ts
@@ -1,0 +1,28 @@
+import { randomUUID } from 'crypto';
+
+export interface DIDDocument {
+  '@context': string[];
+  id: string;
+  service: any[];
+}
+
+export function generateDID(): { did: string; document: DIDDocument } {
+  const id = randomUUID();
+  const did = `did:example:${id}`;
+  const document: DIDDocument = {
+    '@context': ['https://www.w3.org/ns/did/v1'],
+    id: did,
+    service: [],
+  };
+  return { did, document };
+}
+
+export function resolveDID(did: string): DIDDocument {
+  // In a real implementation this would fetch the DID document from a registry
+  // or blockchain. Here we simply construct a placeholder document.
+  return {
+    '@context': ['https://www.w3.org/ns/did/v1'],
+    id: did,
+    service: [],
+  };
+}

--- a/backend/src/controllers/onboarding_controller.ts
+++ b/backend/src/controllers/onboarding_controller.ts
@@ -1,0 +1,17 @@
+import { generateDID, resolveDID, DIDDocument } from '../blockchain/did_service';
+
+export interface ClinicianProfile {
+  name: string;
+  did: string;
+  document: DIDDocument;
+}
+
+export function onboardClinician(name: string): ClinicianProfile {
+  const { did, document } = generateDID();
+  // In a full implementation the clinician record would be persisted here.
+  return { name, did, document };
+}
+
+export function resolveClinician(did: string): DIDDocument {
+  return resolveDID(did);
+}


### PR DESCRIPTION
## Summary
- implement `did_service` for generating and resolving DIDs
- add onboarding helper to create clinician DIDs
- document clinician onboarding utilities

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest` *(fails: SyntaxError in placeholder tests)*

------
https://chatgpt.com/codex/tasks/task_e_686d235d029483208de942c8d2e14f9e