### PR TITLE
Add Dilithium post-quantum crypto module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+This repository now includes an example integration of post-quantum cryptography
+using the Dilithium signature scheme within the blockchain module. The
+`backend/src/blockchain` folder demonstrates how Dilithium can be used to sign
+and verify data prior to submitting transactions on chain.

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,37 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { DilithiumCrypto, DilithiumKeyPair } from './dilithium_crypto';
+
+/**
+ * Simple blockchain integration example that demonstrates
+ * how Dilithium-based signatures could be used.
+ */
+export class BlockchainIntegration {
+  private crypto = new DilithiumCrypto();
+  private keys?: DilithiumKeyPair;
+
+  /**
+   * Initialize the integration by generating a fresh key pair.
+   */
+  async init(): Promise<void> {
+    this.keys = await this.crypto.generateKeyPair();
+  }
+
+  /**
+   * Sign arbitrary data for submission to the blockchain.
+   */
+  async signData(data: Uint8Array): Promise<Uint8Array> {
+    if (!this.keys) {
+      throw new Error('Integration not initialized');
+    }
+    return await this.crypto.signMessage(data, this.keys.privateKey);
+  }
+
+  /**
+   * Verify signed blockchain data.
+   */
+  async verifyData(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+    if (!this.keys) {
+      throw new Error('Integration not initialized');
+    }
+    return await this.crypto.verifySignature(signature, data, this.keys.publicKey);
+  }
+}

--- a/backend/src/blockchain/dilithium_crypto.ts
+++ b/backend/src/blockchain/dilithium_crypto.ts
@@ -1,0 +1,32 @@
+import { dilithium } from 'dilithium-crystals';
+
+export interface DilithiumKeyPair {
+  publicKey: Uint8Array;
+  privateKey: Uint8Array;
+}
+
+/**
+ * Dilithium-based cryptography helper functions.
+ */
+export class DilithiumCrypto {
+  /**
+   * Generate a new Dilithium key pair.
+   */
+  async generateKeyPair(): Promise<DilithiumKeyPair> {
+    return await dilithium.keyPair();
+  }
+
+  /**
+   * Sign a message using the provided private key and return the detached signature.
+   */
+  async signMessage(message: Uint8Array, privateKey: Uint8Array): Promise<Uint8Array> {
+    return await dilithium.signDetached(message, privateKey);
+  }
+
+  /**
+   * Verify a detached signature against the message and public key.
+   */
+  async verifySignature(signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array): Promise<boolean> {
+    return await dilithium.verifyDetached(signature, message, publicKey);
+  }
+}

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,20 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+import { BlockchainIntegration } from './blockchain_integration';
+
+/**
+ * Service class meant to interact with the Polkadot blockchain.
+ * It demonstrates signing data with Dilithium before sending it off chain.
+ */
+export class PolkadotService {
+  private integration = new BlockchainIntegration();
+
+  async initialize(): Promise<void> {
+    await this.integration.init();
+  }
+
+  /**
+   * Example method that signs payloads prior to submission.
+   */
+  async submitPayload(payload: Uint8Array): Promise<Uint8Array> {
+    return this.integration.signData(payload);
+  }
+}


### PR DESCRIPTION
## Summary
- integrate post-quantum cryptography with Dilithium helper module
- demo usage in blockchain integration and Polkadot service
- document post-quantum example in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d23678f94832093e37ac192922f63