### PR TITLE
Implement pluggable crypto layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Crypto Layer
+
+The `backend/src/crypto` folder defines a pluggable interface for post-quantum (PQ) signature schemes. New algorithms can be added by implementing the `PQScheme` interface and swapping it in via `setScheme` from `crypto_manager`.
+
+A basic `DefaultScheme` based on ECDSA is provided along with a stub `DilithiumScheme` implementation.

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,6 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { signMessage } from '../crypto/crypto_manager';
+
+export async function issueCredential(data: string): Promise<string> {
+    const signature = await signMessage(Buffer.from(data));
+    return signature.toString('base64');
+}

--- a/backend/src/crypto/crypto_manager.ts
+++ b/backend/src/crypto/crypto_manager.ts
@@ -1,0 +1,21 @@
+import { PQScheme } from './pq_scheme';
+import { DefaultScheme } from './default_scheme';
+
+let activeScheme: PQScheme = new DefaultScheme();
+
+export function setScheme(scheme: PQScheme) {
+    activeScheme = scheme;
+}
+
+export function getScheme(): PQScheme {
+    return activeScheme;
+}
+
+export async function signMessage(message: Buffer): Promise<Buffer> {
+    const keys = await activeScheme.keyGen();
+    return activeScheme.sign(keys.privateKey, message);
+}
+
+export async function verifyMessage(publicKey: string, message: Buffer, signature: Buffer): Promise<boolean> {
+    return activeScheme.verify(publicKey, message, signature);
+}

--- a/backend/src/crypto/default_scheme.ts
+++ b/backend/src/crypto/default_scheme.ts
@@ -1,0 +1,27 @@
+import { generateKeyPairSync, createSign, createVerify } from 'crypto';
+import { PQScheme } from './pq_scheme';
+
+export class DefaultScheme implements PQScheme {
+    async keyGen() {
+        const { publicKey, privateKey } = generateKeyPairSync('ec', {
+            namedCurve: 'P-256',
+            publicKeyEncoding: { type: 'spki', format: 'pem' },
+            privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+        });
+        return { publicKey, privateKey };
+    }
+
+    async sign(privateKey: string, message: Buffer): Promise<Buffer> {
+        const sign = createSign('SHA256');
+        sign.update(message);
+        sign.end();
+        return sign.sign(privateKey);
+    }
+
+    async verify(publicKey: string, message: Buffer, signature: Buffer): Promise<boolean> {
+        const verify = createVerify('SHA256');
+        verify.update(message);
+        verify.end();
+        return verify.verify(publicKey, signature);
+    }
+}

--- a/backend/src/crypto/dilithium_scheme.ts
+++ b/backend/src/crypto/dilithium_scheme.ts
@@ -1,0 +1,18 @@
+import { PQScheme } from './pq_scheme';
+
+export class DilithiumScheme implements PQScheme {
+    async keyGen() {
+        // Placeholder implementation. Replace with real Dilithium key generation.
+        return { publicKey: 'dilithium-public-key', privateKey: 'dilithium-private-key' };
+    }
+
+    async sign(_privateKey: string, _message: Buffer): Promise<Buffer> {
+        // Placeholder signing operation for Dilithium.
+        return Buffer.from('dilithium-signature');
+    }
+
+    async verify(_publicKey: string, _message: Buffer, _signature: Buffer): Promise<boolean> {
+        // Placeholder verification. Always returns true for now.
+        return true;
+    }
+}

--- a/backend/src/crypto/pq_scheme.ts
+++ b/backend/src/crypto/pq_scheme.ts
@@ -1,0 +1,5 @@
+export interface PQScheme {
+    keyGen(): Promise<{ publicKey: string; privateKey: string }>;
+    sign(privateKey: string, message: Buffer): Promise<Buffer>;
+    verify(publicKey: string, message: Buffer, signature: Buffer): Promise<boolean>;
+}


### PR DESCRIPTION
## Summary
- add PQScheme interface and default ECDSA implementation
- provide Dilithium stub and crypto manager
- wire credential controller to new crypto layer
- document crypto module in README

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: syntax error in placeholder test)*

------
https://chatgpt.com/codex/tasks/task_e_686d23a104488320b7f0664ad0010b1f