### PR TITLE
Implement credential status list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Credential Status List
+
+The backend now includes a simple on-chain Credential Status List example. The
+`CredentialStatusList` and `PolkadotService` classes demonstrate how credentials
+can be registered as **active** or **revoked**. Although the implementation is
+in-memory, it mirrors how an on-chain registry might behave.

--- a/backend/__tests__/credential_status_list.test.ts
+++ b/backend/__tests__/credential_status_list.test.ts
@@ -1,0 +1,26 @@
+import { CredentialState } from '../src/blockchain/credential_status_list';
+import { PolkadotService } from '../src/blockchain/polkadot_service';
+const assert = require("assert");
+
+const svc = new PolkadotService();
+
+// Register should make credential active
+svc.registerCredential('cred1');
+assert.strictEqual(svc.getCredentialState('cred1'), CredentialState.ACTIVE);
+
+// Revoking should set status to revoked
+svc.registerCredential('cred2');
+svc.revokeCredential('cred2');
+assert.strictEqual(svc.getCredentialState('cred2'), CredentialState.REVOKED);
+
+// Revoking an unknown credential should throw
+let errorCaught = false;
+try {
+  svc.revokeCredential('unknown');
+} catch (err) {
+  errorCaught = true;
+}
+assert.ok(errorCaught, 'Expected error when revoking unknown credential');
+
+console.log('All credential status list tests passed');
+

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,33 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { PolkadotService } from './polkadot_service';
+import { CredentialState } from './credential_status_list';
+
+/**
+ * BlockchainIntegration provides a higher level API that the rest of the
+ * backend can use to interact with the underlying blockchain service.
+ */
+export class BlockchainIntegration {
+  private service = new PolkadotService();
+
+  /**
+   * Register a credential and return its active state.
+   */
+  async registerCredential(id: string): Promise<CredentialState> {
+    this.service.registerCredential(id);
+    return this.service.getCredentialState(id)!;
+  }
+
+  /**
+   * Revoke a credential.
+   */
+  async revokeCredential(id: string): Promise<CredentialState> {
+    this.service.revokeCredential(id);
+    return this.service.getCredentialState(id)!;
+  }
+
+  /**
+   * Check if a credential is active.
+   */
+  async isCredentialActive(id: string): Promise<boolean> {
+    return this.service.isCredentialActive(id);
+  }
+}

--- a/backend/src/blockchain/credential_status_list.ts
+++ b/backend/src/blockchain/credential_status_list.ts
@@ -1,0 +1,50 @@
+export enum CredentialState {
+  ACTIVE = 'active',
+  REVOKED = 'revoked'
+}
+
+export interface CredentialStatus {
+  id: string;
+  state: CredentialState;
+}
+
+/**
+ * CredentialStatusList simulates an on-chain registry of credential states.
+ * For the purposes of this codebase it is an in-memory list that could be
+ * backed by an actual blockchain in a real implementation.
+ */
+export class CredentialStatusList {
+  private statuses: Map<string, CredentialState> = new Map();
+
+  /**
+   * Add a credential to the list with ACTIVE state.
+   * If the credential already exists it will be overwritten.
+   */
+  addCredential(id: string) {
+    this.statuses.set(id, CredentialState.ACTIVE);
+  }
+
+  /**
+   * Revoke a credential, setting its state to REVOKED.
+   */
+  revokeCredential(id: string) {
+    if (!this.statuses.has(id)) {
+      throw new Error(`Credential ${id} not found`);
+    }
+    this.statuses.set(id, CredentialState.REVOKED);
+  }
+
+  /**
+   * Get the state of a credential, or undefined if not present.
+   */
+  getStatus(id: string): CredentialState | undefined {
+    return this.statuses.get(id);
+  }
+
+  /**
+   * Determine if a credential is active.
+   */
+  isActive(id: string): boolean {
+    return this.statuses.get(id) === CredentialState.ACTIVE;
+  }
+}

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,35 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+import { CredentialStatusList, CredentialState } from './credential_status_list';
+
+/**
+ * PolkadotService simulates interaction with an on-chain registry for
+ * credential status. In a real implementation this would interact with a
+ * Polkadot smart contract or pallet. Here we simply delegate to an in-memory
+ * CredentialStatusList instance.
+ */
+export class PolkadotService {
+  private statusList = new CredentialStatusList();
+
+  /** Register a credential on-chain with ACTIVE status. */
+  registerCredential(id: string) {
+    this.statusList.addCredential(id);
+  }
+
+  /** Revoke a credential on-chain. */
+  revokeCredential(id: string) {
+    this.statusList.revokeCredential(id);
+  }
+
+  /**
+   * Retrieve the current state for a credential.
+   */
+  getCredentialState(id: string): CredentialState | undefined {
+    return this.statusList.getStatus(id);
+  }
+
+  /**
+   * Convenience method to check if credential is active.
+   */
+  isCredentialActive(id: string): boolean {
+    return this.statusList.isActive(id);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add CredentialStatusList with active/revoked states
- integrate PolkadotService and BlockchainIntegration with the status list
- provide a ts-node config file
- document the feature in README
- include a simple test script

## Testing
- `npx ts-node --project tsconfig.json backend/__tests__/credential_status_list.test.ts` *(fails: Cannot find module 'assert')*

------
https://chatgpt.com/codex/tasks/task_e_686d244bd8348320919dbd5a21879624