### PR TITLE
Implement node monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Blockchain Monitoring
+
+The backend includes a simple monitoring utility for checking node health and detecting forks on a Substrate-based network.
+
+### Usage
+
+1. Install dependencies (requires Node.js):
+   ```bash
+   cd backend && npm install
+   ```
+2. Start the monitor (update the WebSocket endpoint as needed):
+   ```bash
+   npm run monitor
+   ```
+
+The monitor connects to the node via WebSocket, periodically checks the finalized head, and prints a message if a fork is detected.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "chai-vc-backend",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "monitor": "ts-node src/blockchain/node_monitor.ts"
+  },
+  "dependencies": {
+    "@polkadot/api": "^10.9.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.5"
+  }
+}

--- a/backend/src/blockchain/node_monitor.ts
+++ b/backend/src/blockchain/node_monitor.ts
@@ -1,0 +1,52 @@
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
+export interface ForkEvent {
+  previousBlock: string;
+  newBlock: string;
+}
+
+export class NodeMonitor {
+  private api: ApiPromise | undefined;
+  private lastFinalized: string | undefined;
+
+  constructor(private endpoint: string) {}
+
+  async init(): Promise<void> {
+    const provider = new WsProvider(this.endpoint);
+    this.api = await ApiPromise.create({ provider });
+  }
+
+  async checkHealth(): Promise<boolean> {
+    if (!this.api) throw new Error('API not initialized');
+    const health = await this.api.rpc.system.health();
+    return !health.isSyncing;
+  }
+
+  async detectFork(onFork: (ev: ForkEvent) => void): Promise<void> {
+    if (!this.api) throw new Error('API not initialized');
+    const header = await this.api.rpc.chain.getFinalizedHead();
+    const hex = header.toHex();
+    if (this.lastFinalized && this.lastFinalized !== hex) {
+      onFork({ previousBlock: this.lastFinalized, newBlock: hex });
+    }
+    this.lastFinalized = hex;
+  }
+
+  async start(onFork: (ev: ForkEvent) => void, interval = 60000): Promise<void> {
+    await this.init();
+    // Initial check
+    await this.detectFork(onFork);
+    setInterval(() => {
+      this.detectFork(onFork).catch((e) => console.error('Monitor error', e));
+    }, interval);
+  }
+}
+
+// Example usage when run directly
+if (require.main === module) {
+  const monitor = new NodeMonitor('ws://localhost:9944');
+  monitor
+    .start((ev) => console.log('Fork detected', ev))
+    .then(() => console.log('Monitoring started'))
+    .catch((err) => console.error(err));
+}


### PR DESCRIPTION
## Summary
- add a TypeScript-based node monitor for blockchain health and fork detection
- document how to run the monitor
- define a minimal backend package.json

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ERROR collecting ai-matcher-service/tests/test_matcher.py)*

------
https://chatgpt.com/codex/tasks/task_e_686d27d1dd74832087a75ea68650e925