### PR TITLE
Add auto recovery scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Auto Recovery Scripts
+
+Two utility scripts in the `scripts` directory help maintain cluster health by automatically removing failed resources so Kubernetes can respawn them.
+
+- `auto_recover_failed_pods.sh` watches for pods in a failed or crashing state and deletes them.
+- `auto_recover_nodes.sh` checks for nodes marked `NotReady` and deletes them so the cluster can recreate them.
+
+Run the scripts with executable permission:
+
+```bash
+./scripts/auto_recover_failed_pods.sh [namespace] [interval]
+./scripts/auto_recover_nodes.sh [interval]
+```
+
+Each script loops indefinitely and should be run as a background process or managed by a supervisor.

--- a/scripts/auto_recover_failed_pods.sh
+++ b/scripts/auto_recover_failed_pods.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Simple auto-recovery script for Kubernetes pods
+# Usage: ./auto_recover_failed_pods.sh [namespace] [check_interval_seconds]
+# Default namespace: default
+# Default interval: 30 seconds
+
+NAMESPACE=${1:-default}
+INTERVAL=${2:-30}
+
+while true; do
+  FAILED_PODS=$(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase=Failed -o jsonpath='{.items[*].metadata.name}')
+  CRASHING_PODS=$(kubectl get pods -n "$NAMESPACE" | awk '/CrashLoopBackOff|Error/ {print $1}')
+
+  for POD in $FAILED_PODS $CRASHING_PODS; do
+    echo "Respawning failed pod: $POD"
+    kubectl delete pod "$POD" -n "$NAMESPACE" --ignore-not-found
+  done
+
+  sleep "$INTERVAL"
+done

--- a/scripts/auto_recover_nodes.sh
+++ b/scripts/auto_recover_nodes.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Auto recovery script for Kubernetes nodes
+# Deletes NotReady nodes so that they can be recreated by the cluster
+# Usage: ./auto_recover_nodes.sh [check_interval_seconds]
+# Default interval: 60 seconds
+
+INTERVAL=${1:-60}
+
+while true; do
+  NOT_READY_NODES=$(kubectl get nodes --no-headers | awk '$2 != "Ready" {print $1}')
+  for NODE in $NOT_READY_NODES; do
+    echo "Detected NotReady node: $NODE. Deleting to trigger recreation..."
+    kubectl delete node "$NODE" --ignore-not-found
+  done
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary
- add shell scripts for auto-recovering failed pods and nodes
- document the scripts in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: SyntaxError in placeholder test)*

------
https://chatgpt.com/codex/tasks/task_e_686d33b80c44832085f70c508c8154c1