### PR TITLE
Implement wallet backup service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Wallet Backup
+
+The backend includes a `WalletBackupService` for encrypting a seed phrase with a password. Encrypted backups can be saved to disk and later restored using the same password.

--- a/backend/src/wallet/backup.ts
+++ b/backend/src/wallet/backup.ts
@@ -1,0 +1,47 @@
+export class WalletBackupService {
+    private static algorithm = 'aes-256-cbc';
+
+    /**
+     * Encrypt a seed phrase using a password.
+     */
+    static encryptSeed(seedPhrase: string, password: string): string {
+        const crypto = require('crypto');
+        const key = crypto.scryptSync(password, 'salt', 32);
+        const iv = crypto.randomBytes(16);
+        const cipher = crypto.createCipheriv(this.algorithm, key, iv);
+        const encrypted = Buffer.concat([cipher.update(seedPhrase, 'utf8'), cipher.final()]);
+        return iv.toString('hex') + ':' + encrypted.toString('hex');
+    }
+
+    /**
+     * Decrypt a seed phrase.
+     */
+    static decryptSeed(encryptedSeed: string, password: string): string {
+        const crypto = require('crypto');
+        const [ivHex, dataHex] = encryptedSeed.split(':');
+        const iv = Buffer.from(ivHex, 'hex');
+        const encryptedText = Buffer.from(dataHex, 'hex');
+        const key = crypto.scryptSync(password, 'salt', 32);
+        const decipher = crypto.createDecipheriv(this.algorithm, key, iv);
+        const decrypted = Buffer.concat([decipher.update(encryptedText), decipher.final()]);
+        return decrypted.toString('utf8');
+    }
+
+    /**
+     * Backup the seed phrase to a file, encrypted using the password.
+     */
+    static backupToFile(seedPhrase: string, password: string, filePath: string): void {
+        const fs = require('fs');
+        const encrypted = this.encryptSeed(seedPhrase, password);
+        fs.writeFileSync(filePath, encrypted, { encoding: 'utf8' });
+    }
+
+    /**
+     * Restore the seed phrase from a backup file.
+     */
+    static restoreFromFile(password: string, filePath: string): string {
+        const fs = require('fs');
+        const encrypted = fs.readFileSync(filePath, { encoding: 'utf8' });
+        return this.decryptSeed(encrypted, password);
+    }
+}


### PR DESCRIPTION
## Summary
- document wallet backup service in README
- add wallet backup service for encrypting and restoring seed phrases

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d342a9d608320ae0f246e0f774647