### PR TITLE
Implement DIDComm v2 messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Features
+
+- Placeholder backend and frontend services
+- AI matcher service
+- **New:** DIDComm v2 messaging support for issuer–wallet exchanges

--- a/backend/__tests__/didcomm_service.test.ts
+++ b/backend/__tests__/didcomm_service.test.ts
@@ -1,0 +1,21 @@
+import { strict as assert } from 'assert';
+import { DIDCommService } from '../src/didcomm/didcomm_service';
+
+class StubDIDComm {
+  async packEncrypted(message: any) {
+    return { packed_msg: JSON.stringify(message) };
+  }
+
+  async unpackMessage(packed: string) {
+    return JSON.parse(packed);
+  }
+}
+
+(async () => {
+  const service = new DIDCommService(new StubDIDComm() as any);
+  const msg = { id: '1', body: { hello: 'world' } };
+  const packed = await service['didcomm'].packEncrypted(msg);
+  const unpacked = await service.receiveMessage(packed.packed_msg);
+  assert.deepEqual(unpacked, msg);
+  console.log('didcomm_service test passed');
+})();

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,15 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { DIDComm } from 'didcomm';
+import { DIDCommService } from '../didcomm/didcomm_service';
+
+// Example integration that wires DIDComm messaging into the blockchain layer.
+export class BlockchainIntegration {
+  private messaging: DIDCommService;
+
+  constructor(didcomm: DIDComm) {
+    this.messaging = new DIDCommService(didcomm);
+  }
+
+  async sendCredentialOffer(message: any, endpoint: string) {
+    await this.messaging.sendMessage(message, endpoint);
+  }
+}

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,15 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { DIDComm } from 'didcomm';
+import { BlockchainIntegration } from '../blockchain/blockchain_integration';
+
+// Controller responsible for coordinating credential issuance flows.
+export class CredentialController {
+  private integration: BlockchainIntegration;
+
+  constructor(didcomm: DIDComm) {
+    this.integration = new BlockchainIntegration(didcomm);
+  }
+
+  async issueCredential(credential: any, walletEndpoint: string) {
+    await this.integration.sendCredentialOffer(credential, walletEndpoint);
+  }
+}

--- a/backend/src/didcomm/didcomm_service.ts
+++ b/backend/src/didcomm/didcomm_service.ts
@@ -1,0 +1,38 @@
+import fetch from 'node-fetch';
+import { DIDComm, Message } from 'didcomm';
+
+export class DIDCommService {
+  private didcomm: DIDComm;
+
+  constructor(didcomm: DIDComm) {
+    this.didcomm = didcomm;
+  }
+
+  /**
+   * Send a DIDComm v2 message to the recipient's service endpoint.
+   * This packs the message using authenticated encryption and posts it
+   * to the provided HTTP endpoint.
+   */
+  async sendMessage(message: Message, serviceEndpoint: string): Promise<void> {
+    const packed = await this.didcomm.packEncrypted(
+      message,
+      undefined,
+      undefined
+    );
+
+    await fetch(serviceEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/didcomm-envelope-enc'
+      },
+      body: packed.packed_msg
+    });
+  }
+
+  /**
+   * Unpacks an incoming DIDComm v2 message.
+   */
+  async receiveMessage(packedMessage: string) {
+    return this.didcomm.unpackMessage(packedMessage);
+  }
+}


### PR DESCRIPTION
## Summary
- add DIDComm service with simple send and receive helpers
- wire the service into blockchain integration and credential controller
- include a small test harness for the DIDComm service
- document DIDComm integration in the README

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest` *(fails: syntax error in placeholder test)*

------
https://chatgpt.com/codex/tasks/task_e_686d3451fcc48320ad0381666a3859eb