### PR TITLE
Add selective disclosure wallet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Features
+
+- Verifiable credential issuance and verification (stub).
+- Selective attribute disclosure presentations in the wallet.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,7 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+"""Tests for the AI matcher service."""
+
+
+def test_placeholder() -> None:
+    """Simple placeholder test so pytest runs cleanly."""
+    assert True
+

--- a/backend/__tests__/wallet_test.ts
+++ b/backend/__tests__/wallet_test.ts
@@ -1,0 +1,9 @@
+import { createSelectiveDisclosurePresentation } from "../src/wallet/selective_disclosure";
+
+describe("selective disclosure", () => {
+  it("keeps only requested attributes", () => {
+    const credential = { id: "123", name: "Alice", age: 30, role: "nurse" };
+    const presentation = createSelectiveDisclosurePresentation(credential, ["name", "role"]);
+    expect(presentation.verifiableCredential).toEqual({ id: "123", name: "Alice", role: "nurse" });
+  });
+});

--- a/backend/src/wallet/selective_disclosure.ts
+++ b/backend/src/wallet/selective_disclosure.ts
@@ -1,0 +1,25 @@
+export interface Credential {
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface Presentation {
+  verifiableCredential: Partial<Credential>;
+}
+
+/**
+ * Create a presentation that discloses only selected attributes from the
+ * credential.
+ */
+export function createSelectiveDisclosurePresentation(
+  credential: Credential,
+  attributesToReveal: string[],
+): Presentation {
+  const disclosed: Partial<Credential> = { id: credential.id };
+  for (const key of attributesToReveal) {
+    if (key in credential) {
+      disclosed[key] = credential[key];
+    }
+  }
+  return { verifiableCredential: disclosed };
+}


### PR DESCRIPTION
## Summary
- add new wallet implementation for selective attribute disclosure
- document wallet capability in README
- fix Python placeholder test so pytest runs
- add wallet unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d347190148320ae957046264b53b0