### PR TITLE
Add biometric confirmation stub

### DIFF
--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,15 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { confirmBiometric } from '../utils/biometric_auth';
+
+/**
+ * Signs a verifiable credential after confirming device biometrics.
+ * This is a stub implementation for the Chai VC platform.
+ */
+export async function signCredential(vcData: unknown): Promise<unknown> {
+  const confirmed = await confirmBiometric();
+  if (!confirmed) {
+    throw new Error('Biometric confirmation failed');
+  }
+  // TODO: integrate actual VC signing logic here
+  console.log('VC signed');
+  return vcData;
+}

--- a/backend/src/utils/biometric_auth.ts
+++ b/backend/src/utils/biometric_auth.ts
@@ -1,0 +1,11 @@
+/**
+ * biometric_auth.ts
+ *
+ * Placeholder for biometric confirmation (FaceID/TouchID) when signing
+ * verifiable credentials.
+ * In a real implementation this would use platform-specific APIs.
+ */
+export async function confirmBiometric(): Promise<boolean> {
+  console.log('Simulating biometric confirmation...');
+  return true;
+}


### PR DESCRIPTION
## Summary
- add biometric confirmation module
- require biometric confirmation before signing VCs

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686d34bee2988320a18de9ea7eecd42c