### PR TITLE
Add push notification service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Push Notifications
+
+The backend now includes a `push_notification_service.ts` module that demonstrates
+how to send push notifications using Firebase Cloud Messaging (FCM) and Apple
+Push Notification service (APNs). The implementation is a stub that logs the
+notification payload. In a production environment you would initialize the
+respective SDKs (for example `firebase-admin` or `apn`) with your credentials
+and call `sendFCM()` or `sendAPN()` to alert users about credential updates or
+new job postings.
+

--- a/backend/src/notifications/push_notification_service.ts
+++ b/backend/src/notifications/push_notification_service.ts
@@ -1,0 +1,62 @@
+// push_notification_service.ts - send push notifications via FCM or APNs
+
+// This module demonstrates how the backend might send push notifications
+// for credential and job alerts. Real credentials like server keys or
+// certificates would be needed for production use.
+
+// Import statements are commented out to avoid requiring actual
+// dependencies in this placeholder repository. In a full implementation,
+// you would install 'firebase-admin' for FCM and 'apn' for APNs.
+
+// import * as admin from 'firebase-admin';
+// import * as apn from 'apn';
+
+export type NotificationPayload = {
+  title: string;
+  body: string;
+  data?: Record<string, string>;
+};
+
+/**
+ * Send a push notification via Firebase Cloud Messaging (FCM).
+ *
+ * @param token Device token registered with FCM.
+ * @param payload Notification data to send.
+ */
+export async function sendFCM(token: string, payload: NotificationPayload): Promise<void> {
+  // Example implementation using firebase-admin. This is disabled in the
+  // stub code so the repository can build without extra dependencies.
+  //
+  // const message = {
+  //   token,
+  //   notification: {
+  //     title: payload.title,
+  //     body: payload.body,
+  //   },
+  //   data: payload.data,
+  // };
+  // await admin.messaging().send(message);
+
+  console.log('sendFCM called with:', token, payload);
+}
+
+/**
+ * Send a push notification via Apple Push Notification service (APNs).
+ *
+ * @param token Device token registered with APNs.
+ * @param payload Notification data to send.
+ */
+export async function sendAPN(token: string, payload: NotificationPayload): Promise<void> {
+  // Example implementation using the "apn" package. Disabled in this stub.
+  //
+  // const notification = new apn.Notification({
+  //   alert: {
+  //     title: payload.title,
+  //     body: payload.body,
+  //   },
+  //   payload: payload.data,
+  // });
+  // await apnProvider.send(notification, token);
+
+  console.log('sendAPN called with:', token, payload);
+}


### PR DESCRIPTION
## Summary
- add push notification service with FCM/APNs stubs
- document push notification module in README

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_686d34e4bfb08320a1816f6912f8241f