### PR TITLE
Add OCR credential import helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## OCR-based Credential Import
+
+The backend includes a helper for importing credential data from uploaded documents. It posts files to an external OCR service defined by `OCR_SERVICE_ENDPOINT` and uses the `OCR_SERVICE_API_KEY` for authentication. The service returns extracted credential data which can then be persisted.

--- a/backend/src/controllers/ocr_import_controller.ts
+++ b/backend/src/controllers/ocr_import_controller.ts
@@ -1,0 +1,35 @@
+import fetch from 'node-fetch';
+import * as fs from 'fs';
+
+/**
+ * Import credential data from a document using an OCR service.
+ * This function sends the document to an external AI-powered
+ * document extraction API and returns the parsed credential data.
+ *
+ * The OCR service URL and API key are provided via environment variables:
+ * OCR_SERVICE_ENDPOINT and OCR_SERVICE_API_KEY.
+ */
+export async function importCredentialFromDocument(filePath: string): Promise<any> {
+  const endpoint = process.env.OCR_SERVICE_ENDPOINT;
+  if (!endpoint) {
+    throw new Error('OCR service endpoint not configured');
+  }
+
+  const apiKey = process.env.OCR_SERVICE_API_KEY || '';
+  const fileBuffer = fs.readFileSync(filePath);
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: fileBuffer,
+  });
+
+  if (!response.ok) {
+    throw new Error(`OCR request failed with status ${response.status}`);
+  }
+
+  return await response.json();
+}


### PR DESCRIPTION
## Summary
- add OCR-based credential import helper
- document OCR-based credential import in README

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_686d34f4d4108320bdd7b1e057846f26