### PR TITLE
Fix placeholder test comment

### DIFF
--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform


### PR DESCRIPTION
## Summary
- fix placeholder comment syntax in Python tests to allow running pytest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d34fdd3d88320bd24ff75c0d2bb6a