### PR TITLE
Add share profile QR button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Sharing Profiles
+
+A new example page demonstrates how users can share their profile via QR code. Navigate to `frontend/pages/share-profile.tsx` for a stub implementation using React and the `react-qr-code` package.

--- a/frontend/components/ShareProfileButton.tsx
+++ b/frontend/components/ShareProfileButton.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import QRCode from 'react-qr-code';
+
+interface ShareProfileButtonProps {
+  /**
+   * URL to encode in the QR code.
+   */
+  profileUrl: string;
+}
+
+/**
+ * Renders a button that toggles a QR code containing the user's profile URL.
+ * This is a stub component intended for demonstration.
+ */
+const ShareProfileButton: React.FC<ShareProfileButtonProps> = ({ profileUrl }) => {
+  const [showQR, setShowQR] = useState(false);
+
+  return (
+    <div>
+      <button onClick={() => setShowQR(!showQR)}>
+        Share My Profile
+      </button>
+      {showQR && (
+        <div style={{ marginTop: '1rem' }}>
+          <QRCode value={profileUrl} size={128} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ShareProfileButton;

--- a/frontend/pages/share-profile.tsx
+++ b/frontend/pages/share-profile.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ShareProfileButton from '../components/ShareProfileButton';
+
+/**
+ * Example page showing how the ShareProfileButton could be used.
+ * In a real application the profile URL would likely be generated dynamically.
+ */
+const ShareProfilePage: React.FC = () => {
+  const profileUrl = 'https://example.com/my-profile';
+
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1>My Profile</h1>
+      <ShareProfileButton profileUrl={profileUrl} />
+    </main>
+  );
+};
+
+export default ShareProfilePage;


### PR DESCRIPTION
## Summary
- add example ShareProfileButton component
- add demo page showing QR code sharing
- document the feature in README

## Testing
- `pytest -q` *(fails: SyntaxError in placeholder tests)*

------
https://chatgpt.com/codex/tasks/task_e_686d3504c5fc8320895caea9cfd64b3f