### PR TITLE
Implement State-Chain Gateway skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## State-Chain Gateway
+
+A minimal gateway implementation is provided for synchronising credential data
+with state board data sources. The code lives in
+`backend/src/gateway/state_chain_gateway.ts` and exposes a `StateChainGateway`
+class. The `sync` method currently logs fetched records but can be extended to
+persist them on-chain or in a database.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,5 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# Basic placeholder test for the AI matcher service
+# This ensures pytest runs without failing due to syntax errors.
+
+def test_placeholder():
+    assert True

--- a/backend/src/gateway/state_chain_gateway.ts
+++ b/backend/src/gateway/state_chain_gateway.ts
@@ -1,0 +1,43 @@
+/**
+ * State-Chain Gateway
+ * -------------------
+ * This module provides a simple interface for synchronising credential data with
+ * external state board sources. It exposes a `StateChainGateway` class which can
+ * be extended to integrate real data providers.
+ */
+
+export interface StateBoardRecord {
+  id: string;
+  [key: string]: unknown;
+}
+
+export class StateChainGateway {
+  constructor(private readonly endpoint: string) {}
+
+  /**
+   * Fetch records from the remote state board API.
+   * The default implementation performs a HTTP GET request against
+   * `${endpoint}/records` and returns the parsed JSON response.
+   */
+  async fetchStateBoardRecords(): Promise<StateBoardRecord[]> {
+    const url = `${this.endpoint}/records`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch state board records: ${res.status}`);
+    }
+    return (await res.json()) as StateBoardRecord[];
+  }
+
+  /**
+   * Synchronise the local chain or database with records obtained from the
+   * state board. This stub simply logs the records but in a real implementation
+   * this would write them to the blockchain or another data store.
+   */
+  async sync(): Promise<void> {
+    const records = await this.fetchStateBoardRecords();
+    for (const record of records) {
+      // TODO: integrate with blockchain or database layer
+      console.log(`Syncing record ${record.id}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add TypeScript gateway for syncing with state board APIs
- fix failing test placeholder
- document the new gateway in README

## Testing
- `pytest`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d516cf90c8320b622adf343222104