### PR TITLE
Add state board update simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## State Board Simulation
+
+A simple script demonstrates how a state board CSV update could automatically
+issue Verifiable Credentials (VCs). The script parses a CSV file and writes
+credential files to an output folder.
+
+Run the simulation from the project root using `ts-node` or after compiling
+TypeScript to JavaScript:
+
+```
+node backend/src/simulations/state_board_simulation.ts
+```

--- a/backend/src/simulations/board_update.csv
+++ b/backend/src/simulations/board_update.csv
@@ -1,0 +1,3 @@
+licenseNumber,firstName,lastName,status
+12345,Jane,Doe,Active
+23456,John,Smith,Expired

--- a/backend/src/simulations/state_board_simulation.ts
+++ b/backend/src/simulations/state_board_simulation.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface LicenseRecord {
+  licenseNumber: string;
+  firstName: string;
+  lastName: string;
+  status: string;
+}
+
+/**
+ * Read state board CSV file and parse license records.
+ */
+function readBoardCsv(csvPath: string): LicenseRecord[] {
+  const data = fs.readFileSync(csvPath, 'utf8');
+  const lines = data.trim().split('\n');
+  const [, ...rows] = lines; // skip header
+  return rows.map(row => {
+    const [licenseNumber, firstName, lastName, status] = row.split(',');
+    return { licenseNumber, firstName, lastName, status };
+  });
+}
+
+/**
+ * Issue a VC for a license record. In this simulation the VC is a JSON file
+ * written to the issued_credentials folder.
+ */
+function issueCredential(record: LicenseRecord, outDir: string) {
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir, { recursive: true });
+  }
+  const credential = {
+    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    type: ['VerifiableCredential', 'HealthcareLicense'],
+    issuer: 'did:example:state-board',
+    issuanceDate: new Date().toISOString(),
+    credentialSubject: record,
+  };
+  const outPath = path.join(outDir, `${record.licenseNumber}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(credential, null, 2));
+  console.log(`Issued VC for license ${record.licenseNumber}: ${outPath}`);
+}
+
+/**
+ * Simulate processing a state board update and issuing VCs.
+ */
+function simulate() {
+  const csvPath = path.join(__dirname, 'board_update.csv');
+  const records = readBoardCsv(csvPath);
+  records.forEach(record => issueCredential(record, path.join(__dirname, 'issued_credentials')));
+}
+
+// Run the simulation when executed directly.
+if (require.main === module) {
+  simulate();
+}


### PR DESCRIPTION
## Summary
- add a simulation script that reads a CSV and issues credential JSON files
- document how to run the simulation

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q` *(fails: SyntaxError in test file)*
- `npx ts-node backend/src/simulations/state_board_simulation.ts` *(fails: requires interactive install)*

------
https://chatgpt.com/codex/tasks/task_e_686d51ec4ebc8320a9cdc80cdbd71518