### PR TITLE
Implement revocation registry update

### DIFF
--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,21 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { PolkadotService } from './polkadot_service';
+
+/**
+ * High level blockchain integration used by the rest of the backend.
+ * Currently only exposes a method to update the revocation registry
+ * via the underlying Polkadot service.
+ */
+export class BlockchainIntegration {
+  private polkadot: PolkadotService;
+
+  constructor() {
+    this.polkadot = new PolkadotService();
+  }
+
+  /**
+   * Update the on-chain revocation registry for a credential.
+   */
+  async updateRevocationRegistry(credentialId: string): Promise<void> {
+    await this.polkadot.updateRevocationRegistry(credentialId);
+  }
+}

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,15 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+export class PolkadotService {
+  /**
+   * Update the on-chain revocation registry for a credential.
+   * This is a stubbed implementation that would normally send a
+   * transaction to the Polkadot network. For now it simply logs
+   * the action so other parts of the system can be wired up without
+   * requiring blockchain access.
+   */
+  async updateRevocationRegistry(credentialId: string): Promise<void> {
+    // In a real implementation this would submit an extrinsic to the
+    // revocation registry smart contract.
+    console.log(`Updating on-chain revocation registry for credential: ${credentialId}`);
+    return Promise.resolve();
+  }
+}

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,22 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { PolkadotService } from '../blockchain/polkadot_service';
+
+/**
+ * Issuer API controller for credential operations.
+ */
+export class CredentialController {
+  private polkadot: PolkadotService;
+
+  constructor() {
+    this.polkadot = new PolkadotService();
+  }
+
+  /**
+   * Update the on-chain revocation registry to revoke a credential.
+   * @param credentialId Identifier of the credential to revoke.
+   */
+  async revokeCredential(credentialId: string): Promise<void> {
+    // Delegate to the blockchain service. Errors would be propagated
+    // to the caller so they can be handled by the API layer.
+    await this.polkadot.updateRevocationRegistry(credentialId);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `updateRevocationRegistry` in `PolkadotService`
- connect revocation logic via `BlockchainIntegration`
- expose `CredentialController.revokeCredential` for issuer API

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d5e24c9008320ab1c829e7a190537