### PR TITLE
Notify clinicians and verifiers on revocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Revocation Notifications
+
+When a credential is revoked, clinicians and subscribed verifiers can be notified using the `revokeCredential` controller which relies on `notifyOnRevocation`. The notifier currently logs a message for each recipient as a placeholder for real notification infrastructure.

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,11 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { notifyOnRevocation } from '../notifications/revocation_notifier';
+
+export function revokeCredential(
+  credentialId: string,
+  clinicianEmails: string[],
+  verifierEmails: string[]
+): void {
+  // Placeholder logic for revocation
+  console.log(`Credential ${credentialId} revoked.`);
+  notifyOnRevocation(credentialId, clinicianEmails, verifierEmails);
+}

--- a/backend/src/notifications/revocation_notifier.ts
+++ b/backend/src/notifications/revocation_notifier.ts
@@ -1,0 +1,10 @@
+export function notifyOnRevocation(
+  credentialId: string,
+  clinicianEmails: string[],
+  verifierEmails: string[]
+): void {
+  const allRecipients = [...clinicianEmails, ...verifierEmails];
+  allRecipients.forEach((email) => {
+    console.log(`Sending revocation notice for ${credentialId} to ${email}`);
+  });
+}


### PR DESCRIPTION
## Summary
- add a revocation notification function
- wire notifier into credential controller
- document revocation notifications

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d5e2fe33c83209da1323eeb3bdee3