### PR TITLE
Add CSV bulk credential issuance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Bulk Credential Issuance
+
+The backend now includes a helper to issue credentials from a CSV file. Use `bulkIssueFromCSV` from `backend/src/controllers/bulk_issue.js` and provide a CSV containing the columns `id`, `name`, `issueDate` and `type`. Each row is validated before credentials are issued.

--- a/backend/__tests__/bulk_issue_test.js
+++ b/backend/__tests__/bulk_issue_test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { bulkIssueFromCSV } = require('../src/controllers/bulk_issue');
+
+async function run() {
+  const validCsv = 'id,name,issueDate,type\n1,Alice,2024-01-01,degree\n2,Bob,2024-02-01,license';
+  fs.writeFileSync('valid.csv', validCsv);
+  const count = await bulkIssueFromCSV('valid.csv');
+  assert.strictEqual(count, 2);
+  fs.unlinkSync('valid.csv');
+
+  const invalidCsv = 'id,name,issueDate,type\n3,Charlie,,degree';
+  fs.writeFileSync('invalid.csv', invalidCsv);
+  let threw = false;
+  try {
+    await bulkIssueFromCSV('invalid.csv');
+  } catch (err) {
+    threw = true;
+  }
+  fs.unlinkSync('invalid.csv');
+  assert.ok(threw, 'Should throw on invalid CSV');
+  console.log('bulk_issue_test passed');
+}
+
+run().catch(err => { console.error(err); process.exit(1); });

--- a/backend/src/controllers/bulk_issue.js
+++ b/backend/src/controllers/bulk_issue.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+const { parseCSV, validateRecord } = require('../utils/csv_validator');
+
+async function issueCredential(record) {
+  // Placeholder for real credential issuance logic
+  console.log(`Issuing credential for ${record.name} (${record.id})`);
+  return `issued-${record.id}`;
+}
+
+async function bulkIssueFromCSV(csvPath) {
+  const data = fs.readFileSync(path.resolve(csvPath), 'utf8');
+  const records = parseCSV(data);
+  for (const record of records) {
+    validateRecord(record);
+    await issueCredential(record);
+  }
+  return records.length;
+}
+
+module.exports = { bulkIssueFromCSV, issueCredential };

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,4 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { bulkIssueFromCSV } from './bulk_issue';
+
+// Expose controller functions for credential management
+export { bulkIssueFromCSV };

--- a/backend/src/utils/csv_validator.js
+++ b/backend/src/utils/csv_validator.js
@@ -1,0 +1,24 @@
+function parseCSV(text) {
+  const lines = text.trim().split(/\r?\n/);
+  const headers = lines.shift().split(',').map(h => h.trim());
+  return lines.filter(l => l.trim()).map(line => {
+    const values = line.split(',').map(v => v.trim());
+    const record = {};
+    headers.forEach((h, i) => { record[h] = values[i]; });
+    return record;
+  });
+}
+
+function validateRecord(record) {
+  const required = ['id', 'name', 'issueDate', 'type'];
+  for (const field of required) {
+    if (!record[field]) {
+      throw new Error(`Missing field ${field}`);
+    }
+  }
+  if (isNaN(Date.parse(record.issueDate))) {
+    throw new Error('Invalid issueDate');
+  }
+}
+
+module.exports = { parseCSV, validateRecord };


### PR DESCRIPTION
## Summary
- add a CSV validator utility
- add bulk credential issuance controller
- expose bulk issuing from credential controller
- document usage in README
- add tests for CSV issuance

## Testing
- `node backend/__tests__/bulk_issue_test.js`


------
https://chatgpt.com/codex/tasks/task_e_686d631706008320b171c74a9ed911a4