### PR TITLE
Add bulk issuance test and script

### DIFF
--- a/ai-matcher-service/src/bulk_issuer.py
+++ b/ai-matcher-service/src/bulk_issuer.py
@@ -1,0 +1,42 @@
+import json
+from typing import List, Tuple, Dict
+
+REQUIRED_FIELDS = ["id", "name"]
+DEFAULT_PATH = "ai-matcher-service/tests/data/sample_credentials.json"
+
+
+def validate_records(records: List[Dict]) -> Tuple[List[Dict], List[Dict]]:
+    """Validate each record has required fields.
+
+    Returns a tuple of (valid_records, invalid_records).
+    """
+    valid = []
+    invalid = []
+    for rec in records:
+        if all(field in rec for field in REQUIRED_FIELDS):
+            valid.append(rec)
+        else:
+            invalid.append(rec)
+    return valid, invalid
+
+
+def load_records(path: str) -> List[Dict]:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main(path: str = DEFAULT_PATH) -> None:
+    records = load_records(path)
+    valid, invalid = validate_records(records)
+    print(f"Processed {len(records)} records: {len(valid)} valid, {len(invalid)} malformed")
+    if invalid:
+        print("Malformed entries:")
+        for i, rec in enumerate(invalid, 1):
+            print(f" {i}. {rec}")
+
+
+if __name__ == "__main__":
+    import sys
+
+    file_path = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_PATH
+    main(file_path)

--- a/ai-matcher-service/src/routes/match.py
+++ b/ai-matcher-service/src/routes/match.py
@@ -1,1 +1,1 @@
-// match.py - placeholder or stub for chai-vc-platform
+# match.py - placeholder route for chai-vc-platform

--- a/ai-matcher-service/tests/data/sample_credentials.json
+++ b/ai-matcher-service/tests/data/sample_credentials.json
@@ -1,0 +1,12 @@
+[
+  {"id": 1, "name": "Alice"},
+  {"id": 2, "name": "Bob"},
+  {"id": 3, "name": "Charlie"},
+  {"id": 4, "name": "Dana"},
+  {"id": 5, "name": "Eve"},
+  {"id": 6, "name": "Frank"},
+  {"name": "NoID"},
+  {"id": 8},
+  {"id": 9, "name": "Grace"},
+  {"id": 10, "name": "Heidi"}
+]

--- a/ai-matcher-service/tests/test_bulk_issue.py
+++ b/ai-matcher-service/tests/test_bulk_issue.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+# Allow importing from the src directory
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from bulk_issuer import validate_records, load_records
+
+
+def test_validate_records():
+    records = load_records(os.path.join(os.path.dirname(__file__), 'data', 'sample_credentials.json'))
+    valid, invalid = validate_records(records)
+    assert len(records) == 10
+    assert len(valid) == 8
+    assert len(invalid) == 2

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,4 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder test for chai-vc-platform
+
+def test_placeholder():
+    assert True


### PR DESCRIPTION
## Summary
- provide simple placeholder comment in match route
- fix placeholder test
- add bulk issuance script with validation
- create sample credentials dataset and tests

## Testing
- `pytest -q`
- `python ai-matcher-service/src/bulk_issuer.py`

------
https://chatgpt.com/codex/tasks/task_e_686d63405e08832091411bad032e041f