### PR TITLE
Implement data-minimized credential display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Issuer Portal
+
+The issuer portal UI enforces data-minimization. Credential pages display
+only the fields required for validation (ID, issuer, issuance time and
+status) while ignoring all other data returned by the backend.

--- a/frontend/pages/credentials/[id].tsx
+++ b/frontend/pages/credentials/[id].tsx
@@ -1,1 +1,52 @@
-// [id].tsx - placeholder or stub for chai-vc-platform
+// Credential detail page with data minimization
+
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+interface Credential {
+  id: string
+  issuer: string
+  issuedAt: string
+  status?: string
+}
+
+const ALLOWED_FIELDS = ['id', 'issuer', 'issuedAt', 'status'] as const
+
+function minimizeCredentialData(data: Record<string, any>): Credential {
+  const minimized: Partial<Credential> = {}
+  for (const field of ALLOWED_FIELDS) {
+    if (field in data) {
+      minimized[field] = data[field]
+    }
+  }
+  return minimized as Credential
+}
+
+export default function CredentialPage() {
+  const { query } = useRouter()
+  const [credential, setCredential] = useState<Credential | null>(null)
+
+  useEffect(() => {
+    if (!query.id) return
+
+    fetch(`/api/credentials/${query.id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setCredential(minimizeCredentialData(data))
+      })
+      .catch(() => setCredential(null))
+  }, [query.id])
+
+  if (!credential) return <div>Loading...</div>
+
+  return (
+    <div>
+      <h1>Credential</h1>
+      <p>ID: {credential.id}</p>
+      <p>Issuer: {credential.issuer}</p>
+      <p>Issued At: {credential.issuedAt}</p>
+      {credential.status && <p>Status: {credential.status}</p>}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add credential page that only displays minimal fields
- document data minimization in README

## Testing
- `pytest -q` *(fails: SyntaxError in test placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_686d6356c1bc8320a966c22afaf61a69