### PR TITLE
Implement issuer audit logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+logs/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Audit Logs
+
+Issuer actions are recorded in `logs/issuer_audit.log`. Use `recordIssuerAction` from `backend/src/audit/audit_logger.ts` to append entries.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/backend/src/audit/audit_logger.ts
+++ b/backend/src/audit/audit_logger.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Record an audit log entry for issuer-related actions.
+ *
+ * @param action - Description of the issuer action performed.
+ * @param details - Optional metadata associated with the action.
+ */
+export function recordIssuerAction(action: string, details: unknown = {}): void {
+  const logEntry = {
+    timestamp: new Date().toISOString(),
+    action,
+    details,
+  };
+
+  const logDir = path.join(__dirname, '..', '..', '..', 'logs');
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true });
+  }
+  const logFile = path.join(logDir, 'issuer_audit.log');
+  fs.appendFileSync(logFile, JSON.stringify(logEntry) + '\n');
+}


### PR DESCRIPTION
## Summary
- add a simple audit logger for issuer actions
- document audit logging in README
- ensure placeholder Python test doesn't break collection
- ignore generated logs and Python cache

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686d63c57db88320af2d05f4d5b3f238