### PR TITLE
Add AI match ranking service and frontend fit display

### DIFF
--- a/ai-matcher-service/src/main.py
+++ b/ai-matcher-service/src/main.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+from .routes.match import router as match_router
+
+app = FastAPI(title="AI Matcher Service")
+app.include_router(match_router)
+
+# For uvicorn entry point
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/ai-matcher-service/src/matcher.py
+++ b/ai-matcher-service/src/matcher.py
@@ -1,0 +1,11 @@
+from typing import List, Set
+
+def calculate_fit(candidate_skills: List[str], job_skills: List[str]) -> float:
+    """Return match percentage between candidate and job skills."""
+    candidate: Set[str] = {s.lower() for s in candidate_skills}
+    job: Set[str] = {s.lower() for s in job_skills}
+    if not job:
+        return 0.0
+    intersection = candidate.intersection(job)
+    fit_score = len(intersection) / len(job) * 100
+    return round(fit_score, 2)

--- a/ai-matcher-service/src/routes/match.py
+++ b/ai-matcher-service/src/routes/match.py
@@ -1,1 +1,19 @@
-// match.py - placeholder or stub for chai-vc-platform
+from fastapi import APIRouter
+from pydantic import BaseModel
+from typing import List
+
+from ..matcher import calculate_fit
+
+router = APIRouter()
+
+class MatchRequest(BaseModel):
+    candidate_skills: List[str]
+    job_skills: List[str]
+
+class MatchResponse(BaseModel):
+    fit: float
+
+@router.post("/match", response_model=MatchResponse)
+async def match_endpoint(req: MatchRequest) -> MatchResponse:
+    fit = calculate_fit(req.candidate_skills, req.job_skills)
+    return MatchResponse(fit=fit)

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,18 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from matcher import calculate_fit
+
+
+def test_perfect_match():
+    assert calculate_fit(["python", "fastapi"], ["python", "fastapi"]) == 100.0
+
+
+def test_partial_match():
+    assert calculate_fit(["python", "fastapi"], ["python", "docker"]) == 50.0
+
+
+def test_no_job_skills():
+    assert calculate_fit(["python"], []) == 0.0

--- a/frontend/pages/credentials/[id].tsx
+++ b/frontend/pages/credentials/[id].tsx
@@ -1,1 +1,34 @@
-// [id].tsx - placeholder or stub for chai-vc-platform
+import { useEffect, useState } from 'react';
+
+export default function CredentialDetail() {
+  const [fit, setFit] = useState<number | null>(null);
+
+  useEffect(() => {
+    async function fetchFit() {
+      try {
+        const res = await fetch('http://localhost:8000/match', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            candidate_skills: ['react', 'node'],
+            job_skills: ['react', 'typescript', 'node']
+          })
+        });
+        const data = await res.json();
+        setFit(data.fit);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchFit();
+  }, []);
+
+  return (
+    <div>
+      <h1>Credential Detail</h1>
+      {fit !== null && (
+        <p>Fit: {fit}%</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `calculate_fit` matcher algorithm
- expose `/match` API with FastAPI
- provide minimal server entry point
- show match percentage on credential profile page
- add unit tests for matcher

## Testing
- `pytest ai-matcher-service/tests/test_matcher.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686d63ed20908320898a842059cc5cbb