### PR TITLE
Add fairness audit indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+This demo includes a basic fairness audit indicator. When bias mitigation is applied to a credential, the UI displays a notice confirming that a fairness audit was performed.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,4 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform
+
+def test_placeholder():
+    assert True

--- a/frontend/components/FairnessAuditIndicator.tsx
+++ b/frontend/components/FairnessAuditIndicator.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface FairnessAuditIndicatorProps {
+  biasMitigationApplied: boolean;
+}
+
+const FairnessAuditIndicator: React.FC<FairnessAuditIndicatorProps> = ({ biasMitigationApplied }) => {
+  if (!biasMitigationApplied) {
+    return null;
+  }
+  return (
+    <div style={{ padding: '10px', backgroundColor: '#e0ffe0', border: '1px solid #008000' }}>
+      Fairness audit: Bias mitigation applied
+    </div>
+  );
+};
+
+export default FairnessAuditIndicator;

--- a/frontend/pages/credentials/[id].tsx
+++ b/frontend/pages/credentials/[id].tsx
@@ -1,1 +1,20 @@
-// [id].tsx - placeholder or stub for chai-vc-platform
+import { useRouter } from 'next/router';
+import React from 'react';
+import FairnessAuditIndicator from '../../components/FairnessAuditIndicator';
+
+const CredentialPage: React.FC = () => {
+  const router = useRouter();
+  const { id, biasMitigation } = router.query;
+
+  const biasMitigationApplied = biasMitigation === '1' || biasMitigation === 'true';
+
+  return (
+    <div>
+      <h1>Credential {id}</h1>
+      <FairnessAuditIndicator biasMitigationApplied={biasMitigationApplied} />
+      {/* Additional credential details would be rendered here */}
+    </div>
+  );
+};
+
+export default CredentialPage;


### PR DESCRIPTION
## Summary
- add FairnessAuditIndicator component
- show fairness audit indicator on credential page
- fix placeholder Python test so `pytest` runs
- document fairness audit indicator in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d63ff5ce48320bc92ad332598632e