### PR TITLE
Add verification widget

### DIFF
--- a/frontend/components/PrimarySourceVerificationWidget.tsx
+++ b/frontend/components/PrimarySourceVerificationWidget.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+export default function PrimarySourceVerificationWidget() {
+  const [id, setId] = useState('');
+  const [status, setStatus] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function verify() {
+    setLoading(true);
+    setStatus(null);
+    try {
+      const res = await fetch(`/api/verify?id=${encodeURIComponent(id)}`);
+      if (!res.ok) throw new Error('Network response was not ok');
+      const data = await res.json();
+      setStatus(data.status);
+    } catch (err) {
+      setStatus('error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem' }}>
+      <h3>Primary Source Verification</h3>
+      <input
+        type="text"
+        placeholder="Credential ID"
+        value={id}
+        onChange={e => setId(e.target.value)}
+      />
+      <button onClick={verify} disabled={loading || !id} style={{ marginLeft: '0.5rem' }}>
+        Verify
+      </button>
+      {loading && <p>Verifying...</p>}
+      {status && !loading && <p>Result: {status}</p>}
+    </div>
+  );
+}

--- a/frontend/pages/api/verify.ts
+++ b/frontend/pages/api/verify.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  if (!id) {
+    res.status(400).json({ status: 'missing id' });
+    return;
+  }
+
+  // Stubbed verification logic - randomly succeed or fail
+  const verified = Math.random() > 0.5;
+  const status = verified ? 'verified' : 'unverified';
+  res.status(200).json({ status });
+}

--- a/frontend/pages/verify.tsx
+++ b/frontend/pages/verify.tsx
@@ -1,0 +1,12 @@
+import dynamic from 'next/dynamic';
+
+const PrimarySourceVerificationWidget = dynamic(() => import('../components/PrimarySourceVerificationWidget'), { ssr: false });
+
+export default function VerifyPage() {
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1>Credential Verification</h1>
+      <PrimarySourceVerificationWidget />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add basic primary source verification widget
- stub API route for verification
- show widget in a new verification page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d641c50c08320969c29d37510b896