### PR TITLE
Add continuous monitoring alerts page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Continuous Monitoring Alerts Panel
+
+Verifiers can access continuous monitoring alerts at `/verifiers/alerts`. The
+page lists recent alerts such as license expirations or new sanctions so that
+verification teams can react quickly.

--- a/frontend/pages/verifiers/alerts.tsx
+++ b/frontend/pages/verifiers/alerts.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface Alert {
+  id: number;
+  message: string;
+  timestamp: string;
+}
+
+const sampleAlerts: Alert[] = [
+  { id: 1, message: 'License about to expire for Dr. Smith', timestamp: '2023-08-01 10:00' },
+  { id: 2, message: 'New sanction found for Jane Doe', timestamp: '2023-08-02 14:30' },
+];
+
+const AlertsPage: React.FC = () => {
+  return (
+    <div>
+      <h1>Continuous Monitoring Alerts</h1>
+      <ul>
+        {sampleAlerts.map(alert => (
+          <li key={alert.id}>
+            <strong>{alert.message}</strong>
+            <br />
+            <span>{alert.timestamp}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AlertsPage;


### PR DESCRIPTION
## Summary
- implement a simple continuous monitoring alerts panel for verifiers
- document how to access the new panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d675ef15c832084ee05058a934c60