### PR TITLE
Add simple verifier audit trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Audit Trail
+
+The backend includes a simple audit trail used by verifiers. Events are logged to
+`backend/src/audit/audit_log.json`. Utility functions are available to record
+profile views, credential downloads, and successful hires.

--- a/backend/__tests__/audit_trail_test.ts
+++ b/backend/__tests__/audit_trail_test.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+import { recordProfileView, recordDownload, recordHire, getAuditTrail } from '../src/audit/audit_trail';
+
+describe('audit trail', () => {
+  const logFile = path.join(__dirname, '../src/audit/audit_log.json');
+
+  beforeEach(() => {
+    if (fs.existsSync(logFile)) {
+      fs.unlinkSync(logFile);
+    }
+  });
+
+  it('records profile views, downloads, and hires', () => {
+    recordProfileView('user1', 'profileA');
+    recordDownload('user1', 'profileA');
+    recordHire('user1', 'profileA');
+    const events = getAuditTrail();
+    expect(events.length).toBe(3);
+    expect(events[0].type).toBe('PROFILE_VIEW');
+    expect(events[1].type).toBe('DOWNLOAD');
+    expect(events[2].type).toBe('HIRE');
+  });
+});

--- a/backend/src/audit/audit_trail.ts
+++ b/backend/src/audit/audit_trail.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+
+export type AuditEventType = 'PROFILE_VIEW' | 'DOWNLOAD' | 'HIRE';
+
+export interface AuditEvent {
+  timestamp: string;
+  type: AuditEventType;
+  userId: string;
+  profileId: string;
+}
+
+const logFile = path.join(__dirname, 'audit_log.json');
+
+function loadEvents(): AuditEvent[] {
+  try {
+    const data = fs.readFileSync(logFile, 'utf8');
+    return JSON.parse(data) as AuditEvent[];
+  } catch {
+    return [];
+  }
+}
+
+function saveEvents(events: AuditEvent[]) {
+  fs.writeFileSync(logFile, JSON.stringify(events, null, 2));
+}
+
+export function recordEvent(event: AuditEvent): void {
+  const events = loadEvents();
+  events.push(event);
+  saveEvents(events);
+}
+
+export function recordProfileView(userId: string, profileId: string): void {
+  recordEvent({ timestamp: new Date().toISOString(), type: 'PROFILE_VIEW', userId, profileId });
+}
+
+export function recordDownload(userId: string, profileId: string): void {
+  recordEvent({ timestamp: new Date().toISOString(), type: 'DOWNLOAD', userId, profileId });
+}
+
+export function recordHire(userId: string, profileId: string): void {
+  recordEvent({ timestamp: new Date().toISOString(), type: 'HIRE', userId, profileId });
+}
+
+export function getAuditTrail(): AuditEvent[] {
+  return loadEvents();
+}


### PR DESCRIPTION
## Summary
- implement audit trail module for profile views, downloads and hires
- add accompanying unit test skeleton
- document audit trail usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d6fa286208320b4190283b16867dd