### PR TITLE
Add job ingestion API service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Job Ingestion Service
+
+A minimal FastAPI service provides endpoints to ingest and list job postings.
+
+### Install dependencies
+
+```bash
+pip install fastapi uvicorn
+```
+
+### Run the service
+
+```bash
+uvicorn job_ingestion_service.main:app --reload
+```
+
+POST new jobs to `/jobs` with JSON body containing `title` and `description`.
+Retrieve all jobs with `GET /jobs`.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,4 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform
+
+def test_placeholder():
+    assert True

--- a/job_ingestion_service/main.py
+++ b/job_ingestion_service/main.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import json
+from pathlib import Path
+
+app = FastAPI(title="Job Ingestion Service")
+
+DATA_FILE = Path(__file__).parent / "jobs_data.json"
+
+# In-memory job store
+jobs = []
+
+# Load existing jobs on startup
+if DATA_FILE.exists():
+    try:
+        jobs = json.loads(DATA_FILE.read_text())
+    except Exception:
+        jobs = []
+
+class Job(BaseModel):
+    title: str
+    description: str
+
+@app.post("/jobs", status_code=201)
+def create_job(job: Job):
+    jobs.append(job.model_dump())
+    DATA_FILE.write_text(json.dumps(jobs, indent=2))
+    return {"message": "Job ingested"}
+
+@app.get("/jobs")
+def list_jobs():
+    return jobs


### PR DESCRIPTION
## Summary
- add a FastAPI-based job ingestion API
- fix placeholder test to be valid Python
- document how to run the new service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d7874f3bc8320ae871a2afc9e658b