### PR TITLE
Add match recomputation triggers

### DIFF
--- a/ai-matcher-service/src/app.py
+++ b/ai-matcher-service/src/app.py
@@ -1,0 +1,13 @@
+from flask import Flask
+from routes.match import match_blueprint
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.register_blueprint(match_blueprint)
+    return app
+
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(host='0.0.0.0', port=8000)

--- a/ai-matcher-service/src/routes/match.py
+++ b/ai-matcher-service/src/routes/match.py
@@ -1,1 +1,29 @@
-// match.py - placeholder or stub for chai-vc-platform
+from flask import Blueprint, request, jsonify
+
+match_blueprint = Blueprint('match', __name__)
+
+
+def recompute_matches(entity_type: str, entity_id: str):
+    """Placeholder implementation for match recomputation."""
+    # In a real system, this would trigger the matching algorithm.
+    print(f"Recomputing matches for {entity_type} {entity_id}")
+
+
+@match_blueprint.route('/profiles', methods=['POST'])
+def new_profile():
+    data = request.get_json(force=True, silent=True) or {}
+    profile_id = data.get('profile_id')
+    if not profile_id:
+        return jsonify({'error': 'profile_id is required'}), 400
+    recompute_matches('profile', profile_id)
+    return jsonify({'status': 'recomputed'}), 200
+
+
+@match_blueprint.route('/jobs', methods=['POST'])
+def new_job():
+    data = request.get_json(force=True, silent=True) or {}
+    job_id = data.get('job_id')
+    if not job_id:
+        return jsonify({'error': 'job_id is required'}), 400
+    recompute_matches('job', job_id)
+    return jsonify({'status': 'recomputed'}), 200

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,23 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+import os
+import sys
+
+# Allow importing from the src directory
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from app import create_app
+
+
+def test_recompute_on_new_profile():
+    app = create_app()
+    client = app.test_client()
+    resp = client.post('/profiles', json={'profile_id': '123'})
+    assert resp.status_code == 200
+    assert resp.get_json()['status'] == 'recomputed'
+
+
+def test_recompute_on_new_job():
+    app = create_app()
+    client = app.test_client()
+    resp = client.post('/jobs', json={'job_id': 'abc'})
+    assert resp.status_code == 200
+    assert resp.get_json()['status'] == 'recomputed'


### PR DESCRIPTION
## Summary
- implement Flask blueprint for match recomputation
- expose application entrypoint
- test recomputation on profile/job creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d788a7fa0832080c46772fdf056c5