### PR TITLE
Implement continuous learning for model

### DIFF
--- a/ai-matcher-service/data/hiring_outcomes.csv
+++ b/ai-matcher-service/data/hiring_outcomes.csv
@@ -1,0 +1,3 @@
+education_level,years_experience,hired
+PhD,2,1
+Bachelor,7,0

--- a/ai-matcher-service/data/training_data.csv
+++ b/ai-matcher-service/data/training_data.csv
@@ -1,0 +1,3 @@
+education_level,years_experience,hired
+Bachelor,5,1
+Master,3,0

--- a/ai-matcher-service/src/update_model.py
+++ b/ai-matcher-service/src/update_model.py
@@ -1,0 +1,52 @@
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+import joblib
+from pathlib import Path
+
+
+def load_csv(path: Path) -> pd.DataFrame:
+    """Load a CSV file into a DataFrame."""
+    return pd.read_csv(path)
+
+
+def merge_datasets(train_df: pd.DataFrame, new_df: pd.DataFrame) -> pd.DataFrame:
+    """Merge existing training data with new outcome data."""
+    return pd.concat([train_df, new_df], ignore_index=True)
+
+
+def preprocess(df: pd.DataFrame):
+    """Preprocess the dataset for model training."""
+    X = pd.get_dummies(df[['education_level', 'years_experience']])
+    y = df['hired']
+    return X, y
+
+
+def train_model(X, y):
+    """Train a logistic regression model."""
+    model = LogisticRegression(solver='liblinear')
+    model.fit(X, y)
+    return model
+
+
+def save_model(model, path: Path):
+    joblib.dump(model, path)
+
+
+def update_model(train_path: Path, outcome_path: Path, model_path: Path):
+    train_df = load_csv(train_path)
+    outcome_df = load_csv(outcome_path)
+    combined = merge_datasets(train_df, outcome_df)
+
+    X, y = preprocess(combined)
+    model = train_model(X, y)
+
+    save_model(model, model_path)
+    combined.to_csv(train_path, index=False)
+
+
+if __name__ == "__main__":
+    base = Path(__file__).resolve().parent.parent / "data"
+    train_file = base / "training_data.csv"
+    outcome_file = base / "hiring_outcomes.csv"
+    model_file = base / "model.pkl"
+    update_model(train_file, outcome_file, model_file)

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/ai-matcher-service/tests/test_update_model.py
+++ b/ai-matcher-service/tests/test_update_model.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+from update_model import update_model
+
+
+def test_update_model(tmp_path: Path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    train_file = data_dir / "training.csv"
+    outcome_file = data_dir / "outcomes.csv"
+    model_file = data_dir / "model.pkl"
+
+    train_df = pd.DataFrame({
+        "education_level": ["Bachelor", "Master"],
+        "years_experience": [5, 3],
+        "hired": [1, 0],
+    })
+    train_df.to_csv(train_file, index=False)
+
+    outcome_df = pd.DataFrame({
+        "education_level": ["PhD", "Bachelor"],
+        "years_experience": [2, 7],
+        "hired": [1, 0],
+    })
+    outcome_df.to_csv(outcome_file, index=False)
+
+    update_model(train_file, outcome_file, model_file)
+
+    updated = pd.read_csv(train_file)
+    assert len(updated) == 4
+    assert model_file.exists()


### PR DESCRIPTION
## Summary
- add initial training and outcome sample data
- implement `update_model.py` to merge new outcomes and retrain a model
- add tests for the update_model pipeline
- fix placeholder test syntax

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d78d3c1b08320883ef39165d43a99