### PR TITLE
Add candidate explanation UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Why this candidate?
+
+The application exposes a candidate overview page under `pages/credentials/[id].tsx` that displays a short explanation for why a candidate matches a role. This data is served from the stub API route `pages/api/candidate/[id].ts`.

--- a/frontend/pages/api/candidate/[id].ts
+++ b/frontend/pages/api/candidate/[id].ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  res.status(200).json({
+    id,
+    name: `Candidate ${id}`,
+    explanation:
+      'Candidate ' +
+      id +
+      ' matches the job requirements because of relevant experience and certifications.',
+  });
+}

--- a/frontend/pages/credentials/[id].tsx
+++ b/frontend/pages/credentials/[id].tsx
@@ -1,1 +1,33 @@
-// [id].tsx - placeholder or stub for chai-vc-platform
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+interface CandidateData {
+  id: string | string[];
+  name: string;
+  explanation: string;
+}
+
+export default function CredentialDetails() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [candidate, setCandidate] = useState<CandidateData | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/candidate/${id}`)
+      .then((res) => res.json())
+      .then((data) => setCandidate(data));
+  }, [id]);
+
+  if (!candidate) {
+    return <p>Loading...</p>;
+  }
+
+  return (
+    <div>
+      <h1>{candidate.name}</h1>
+      <h2>Why this candidate?</h2>
+      <p>{candidate.explanation}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show candidate matching explanation on credential page
- serve candidate data via stub API endpoint
- document the new "Why this candidate?" section in the README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d795afffc8320a5c860092f0d3aeb