### PR TITLE
Add NPPES NPI lookup service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## NPI Lookup
+
+The onboarding flow now integrates a lookup against the public NPPES NPI Registry. The helper found in `backend/src/services/npi_lookup.ts` fetches provider information from the CMS API. `getProviderInfo` in `backend/src/controllers/onboarding_controller.ts` is a thin wrapper used during onboarding to resolve basic provider details by NPI number.

--- a/backend/src/controllers/onboarding_controller.ts
+++ b/backend/src/controllers/onboarding_controller.ts
@@ -1,0 +1,5 @@
+import { lookupNpi } from '../services/npi_lookup';
+
+export async function getProviderInfo(npi: string) {
+  return await lookupNpi(npi);
+}

--- a/backend/src/services/npi_lookup.ts
+++ b/backend/src/services/npi_lookup.ts
@@ -1,0 +1,32 @@
+export interface NpiProvider {
+  number: string;
+  enumeration_type: string;
+  basic: Record<string, any>;
+}
+
+export async function lookupNpi(number: string): Promise<NpiProvider | null> {
+  const url = `https://npiregistry.cms.hhs.gov/api/?number=${encodeURIComponent(number)}&version=2.1`;
+  return new Promise((resolve, reject) => {
+    const https = require('https');
+    https
+      .get(url, (res: any) => {
+        let data = '';
+        res.on('data', (chunk: any) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          try {
+            const json = JSON.parse(data);
+            if (json.results && json.results.length > 0) {
+              resolve(json.results[0] as NpiProvider);
+            } else {
+              resolve(null);
+            }
+          } catch (err) {
+            reject(err);
+          }
+        });
+      })
+      .on('error', (err: any) => reject(err));
+  });
+}


### PR DESCRIPTION
## Summary
- add a simple `lookupNpi` helper that queries the NPPES public API
- expose `getProviderInfo` for use during onboarding
- document the new lookup service in the README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: SyntaxError in placeholder test)*

------
https://chatgpt.com/codex/tasks/task_e_686d797d67908320983fefc50ab57406