### PR TITLE
Add NPI validation utility

### DIFF
--- a/frontend/pages/credentials/[id].tsx
+++ b/frontend/pages/credentials/[id].tsx
@@ -1,1 +1,24 @@
-// [id].tsx - placeholder or stub for chai-vc-platform
+import React, { useState } from 'react';
+import { isValidNPI } from '../../utils/validateNpi';
+
+const CredentialPage = () => {
+  const [npi, setNpi] = useState('');
+  const valid = npi ? isValidNPI(npi) : null;
+
+  return (
+    <div>
+      <h1>Credential</h1>
+      <input
+        type="text"
+        value={npi}
+        onChange={(e) => setNpi(e.target.value)}
+        placeholder="Enter NPI"
+      />
+      {valid !== null && (
+        <p>{valid ? 'NPI is valid' : 'NPI is invalid'}</p>
+      )}
+    </div>
+  );
+};
+
+export default CredentialPage;

--- a/frontend/utils/validateNpi.js
+++ b/frontend/utils/validateNpi.js
@@ -1,0 +1,27 @@
+/**
+ * Validate an NPI number using format and Luhn checksum.
+ * The check digit is calculated with the standard NPI prefix 80840.
+ * @param {string} npi - 10 digit National Provider Identifier
+ * @returns {boolean} true if the NPI is valid
+ */
+function isValidNPI(npi) {
+  if (typeof npi !== 'string') return false;
+  const digits = npi.replace(/\D/g, '');
+  if (digits.length !== 10) return false;
+  const nums = digits.split('').map(Number);
+  const prefix = [8, 0, 8, 4, 0];
+  const payload = prefix.concat(nums.slice(0, 9));
+  let sum = 0;
+  for (let i = payload.length - 1; i >= 0; i--) {
+    let val = payload[i];
+    if ((payload.length - i) % 2 === 1) {
+      val *= 2;
+      if (val > 9) val -= 9;
+    }
+    sum += val;
+  }
+  const checkDigit = (10 - (sum % 10)) % 10;
+  return checkDigit === nums[9];
+}
+
+module.exports = { isValidNPI };

--- a/frontend/utils/validateNpi.test.js
+++ b/frontend/utils/validateNpi.test.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { isValidNPI } = require('./validateNpi');
+
+assert.strictEqual(isValidNPI('1234567893'), true);
+assert.strictEqual(isValidNPI('1234567890'), false);
+assert.strictEqual(isValidNPI('1992757165'), true);
+assert.strictEqual(isValidNPI('1992757164'), false);
+
+console.log('validateNpi tests passed');


### PR DESCRIPTION
## Summary
- validate NPI format and checksum
- show simple NPI validation on credential page
- add unit tests for validation logic

## Testing
- `node frontend/utils/validateNpi.test.js`

------
https://chatgpt.com/codex/tasks/task_e_686d798889ac8320a80effdd25ce577f