### PR TITLE
Add simple onboarding UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Onboarding UI
+
+This repo includes a simple multi-step onboarding flow located at
+`frontend/pages/onboarding.tsx`.
+
+1. **NPI Entry** – users provide their NPI.
+2. **Confirm/Edit** – review or edit basic details.
+3. **OTP** – enter a one-time passcode for verification.
+4. **Success** – completion screen.
+
+The flow is purposefully lightweight and demonstrates how the platform
+could collect provider details before issuing credentials.

--- a/frontend/pages/onboarding.tsx
+++ b/frontend/pages/onboarding.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+
+// Simple multi-step onboarding UI
+export default function Onboarding() {
+  const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
+  const [npi, setNpi] = useState('');
+  const [name, setName] = useState('');
+  const [otp, setOtp] = useState('');
+
+  const next = () => setStep((prev) => (prev < 4 ? (prev + 1) as any : prev));
+  const back = () => setStep((prev) => (prev > 1 ? (prev - 1) as any : prev));
+
+  return (
+    <div style={{ padding: '2rem', maxWidth: '400px', margin: '0 auto' }}>
+      {step === 1 && (
+        <div>
+          <h1>Enter NPI</h1>
+          <input
+            type="text"
+            placeholder="NPI"
+            value={npi}
+            onChange={(e) => setNpi(e.target.value)}
+            style={{ width: '100%', padding: '0.5rem' }}
+          />
+          <button onClick={next} style={{ marginTop: '1rem' }}>Next</button>
+        </div>
+      )}
+      {step === 2 && (
+        <div>
+          <h1>Confirm Details</h1>
+          <label>
+            Name
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              style={{ width: '100%', padding: '0.5rem', marginTop: '0.5rem' }}
+            />
+          </label>
+          <button onClick={back} style={{ marginTop: '1rem', marginRight: '0.5rem' }}>
+            Back
+          </button>
+          <button onClick={next} style={{ marginTop: '1rem' }}>Confirm</button>
+        </div>
+      )}
+      {step === 3 && (
+        <div>
+          <h1>Enter OTP</h1>
+          <input
+            type="text"
+            placeholder="OTP"
+            value={otp}
+            onChange={(e) => setOtp(e.target.value)}
+            style={{ width: '100%', padding: '0.5rem' }}
+          />
+          <button onClick={back} style={{ marginTop: '1rem', marginRight: '0.5rem' }}>
+            Back
+          </button>
+          <button onClick={next} style={{ marginTop: '1rem' }}>Verify</button>
+        </div>
+      )}
+      {step === 4 && (
+        <div>
+          <h1>Success!</h1>
+          <p>You have completed onboarding.</p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a basic multi-step onboarding flow
- document onboarding flow in README

## Testing
- `pytest -q` *(fails: SyntaxError in placeholder test)*

------
https://chatgpt.com/codex/tasks/task_e_686d89fc20108320921c711f62ad0e43