### PR TITLE
Add manual entry fallback on NPI lookup failure

### DIFF
--- a/backend/__tests__/npi_lookup_test.ts
+++ b/backend/__tests__/npi_lookup_test.ts
@@ -1,0 +1,8 @@
+import assert from 'assert';
+import { getProviderInfo } from '../src/controllers/credential_controller';
+
+(async () => {
+  const result = await getProviderInfo('0000000000');
+  assert.strictEqual(result.manualEntryRequired, true, 'Should require manual entry when lookup fails');
+  console.log('Test passed');
+})();

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,15 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { lookupNPI, ProviderDetails } from '../utils/npiLookup';
+
+export interface ProviderLookupResponse {
+  provider?: ProviderDetails;
+  manualEntryRequired: boolean;
+}
+
+// Fetch provider information via NPI. If lookup fails, indicate manual entry.
+export async function getProviderInfo(npi: string): Promise<ProviderLookupResponse> {
+  const provider = await lookupNPI(npi);
+  if (provider) {
+    return { provider, manualEntryRequired: false };
+  }
+  return { manualEntryRequired: true };
+}

--- a/backend/src/utils/npiLookup.ts
+++ b/backend/src/utils/npiLookup.ts
@@ -1,0 +1,27 @@
+export interface ProviderDetails {
+  firstName: string;
+  lastName: string;
+  enumerationType: string;
+}
+
+export async function lookupNPI(npi: string): Promise<ProviderDetails | null> {
+  const url = `https://npiregistry.cms.hhs.gov/api/?number=${npi}&version=2.1`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      return null;
+    }
+    const data = await res.json();
+    if (!data.results || data.results.length === 0) {
+      return null;
+    }
+    const provider = data.results[0].basic;
+    return {
+      firstName: provider.first_name,
+      lastName: provider.last_name,
+      enumerationType: provider.enumeration_type,
+    };
+  } catch (err) {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add NPI lookup utility
- return `manualEntryRequired` from credential controller when lookup fails
- add a simple test script showing the fallback

## Testing
- `npx ts-node backend/__tests__/npi_lookup_test.ts` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_686d8a2768dc8320847b07cb7e737c47