### PR TITLE
Implement state license checker

### DIFF
--- a/backend/__tests__/state_license_checker.test.ts
+++ b/backend/__tests__/state_license_checker.test.ts
@@ -1,0 +1,24 @@
+// state_license_checker.test.ts - basic usage test for the license checker
+import { checkLicenseViaApi, scrapeLicenseStatus } from '../src/licensing/state_license_checker';
+
+describe('state license checker', () => {
+  test('checkLicenseViaApi returns null when API is missing', async () => {
+    const res = await checkLicenseViaApi('XX', '12345');
+    expect(res).toBeNull();
+  });
+
+  test('scrapeLicenseStatus parses HTML snippets', async () => {
+    const html = `<div id='status'>Active</div><span id='exp'>2025-12-31</span>`;
+    const server = require('http').createServer((_, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(html);
+    }).listen(0);
+    const port = (server.address() as any).port;
+    const url = `http://localhost:${port}`;
+    const data = await scrapeLicenseStatus(url, { status: '#status', expiration: '#exp' });
+    expect(data.status).toBe('Active');
+    expect(data.expirationDate).toBe('2025-12-31');
+    server.close();
+  });
+});
+

--- a/backend/src/licensing/state_license_checker.ts
+++ b/backend/src/licensing/state_license_checker.ts
@@ -1,0 +1,59 @@
+// state_license_checker.ts - Automates retrieval of state licensing data
+
+import fetch from 'node-fetch';
+import * as cheerio from 'cheerio';
+
+/**
+ * License information result.
+ */
+export interface LicenseResult {
+  status: string;
+  expirationDate?: string;
+  raw?: any;
+}
+
+/**
+ * Mapping of states that expose public licensing APIs.
+ * The endpoint should accept a `license` query parameter.
+ */
+const API_ENDPOINTS: Record<string, string> = {
+  // Example for states that provide a REST API endpoint:
+  // CA: 'https://api.example.ca.gov/licenses',
+};
+
+/**
+ * Query a state licensing API if it exists for the given state. Returns null if
+ * the state is not configured with an API endpoint.
+ */
+export async function checkLicenseViaApi(
+  state: string,
+  licenseNumber: string
+): Promise<LicenseResult | null> {
+  const endpoint = API_ENDPOINTS[state];
+  if (!endpoint) return null;
+
+  const url = `${endpoint}?license=${encodeURIComponent(licenseNumber)}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`API request failed with status ${res.status}`);
+  }
+  return (await res.json()) as LicenseResult;
+}
+
+/**
+ * Scrape license status from a web page if no API is available.
+ * Selectors specify where to find the status and expiration date in the page.
+ */
+export async function scrapeLicenseStatus(
+  url: string,
+  selectors: { status: string; expiration: string }
+): Promise<LicenseResult> {
+  const html = await fetch(url).then((r) => r.text());
+  const $ = cheerio.load(html);
+
+  const status = $(selectors.status).text().trim();
+  const expirationDate = $(selectors.expiration).text().trim();
+
+  return { status, expirationDate };
+}
+


### PR DESCRIPTION
## Summary
- add TypeScript utility to query licensing APIs or scrape pages
- add unit test showing basic usage

## Testing
- `pytest -q` *(fails: SyntaxError in placeholder test)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d8a744a388320984d696a7b67f544