### PR TITLE
Add provisional VC management stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Provisional Credentials
+
+The backend now provides helpers for labeling newly created credentials as
+"provisional" until they are officially issued. See
+`backend/src/controllers/credential_service.ts` for the in-memory
+implementation.

--- a/backend/__tests__/provisional_vc.test.ts
+++ b/backend/__tests__/provisional_vc.test.ts
@@ -1,0 +1,14 @@
+import { issueProvisionalVC, finalizeVC, listProvisionalVCs } from '../src/controllers/credential_controller';
+
+// Simple demonstration test for provisional VC lifecycle
+
+describe('provisional VC flow', () => {
+  it('marks credentials as provisional then official', () => {
+    const vc = issueProvisionalVC('123', { example: true });
+    expect(vc.status).toBe('provisional');
+
+    finalizeVC('123');
+    const updated = listProvisionalVCs().find(c => c.id === '123');
+    expect(updated).toBeUndefined();
+  });
+});

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,1 +1,11 @@
-// schema.prisma - placeholder or stub for chai-vc-platform
+// Basic schema showing a credential with a provisional status flag
+model Credential {
+  id        String @id
+  data      Json
+  status    CredentialStatus @default(PROVISIONAL)
+}
+
+enum CredentialStatus {
+  PROVISIONAL
+  OFFICIAL
+}

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,17 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { credentialService, Credential } from './credential_service';
+
+/**
+ * API-facing controller for credential operations. This file provides helper
+ * functions used by routes or GraphQL resolvers.
+ */
+export function issueProvisionalVC(id: string, data: unknown): Credential {
+  return credentialService.createProvisional(id, data);
+}
+
+export function finalizeVC(id: string): Credential | undefined {
+  return credentialService.markOfficial(id);
+}
+
+export function listProvisionalVCs(): Credential[] {
+  return credentialService.listProvisional();
+}

--- a/backend/src/controllers/credential_service.ts
+++ b/backend/src/controllers/credential_service.ts
@@ -1,0 +1,45 @@
+export type CredentialStatus = 'provisional' | 'official';
+
+export interface Credential {
+  id: string;
+  data: unknown;
+  status: CredentialStatus;
+}
+
+/**
+ * Simple in-memory controller to manage credentials. In a real
+ * implementation this would use a persistent store.
+ */
+export class CredentialService {
+  private credentials = new Map<string, Credential>();
+
+  /**
+   * Create a credential marked as provisional.
+   */
+  createProvisional(id: string, data: unknown): Credential {
+    const credential: Credential = { id, data, status: 'provisional' };
+    this.credentials.set(id, credential);
+    return credential;
+  }
+
+  /**
+   * Mark an existing credential as officially issued.
+   */
+  markOfficial(id: string): Credential | undefined {
+    const credential = this.credentials.get(id);
+    if (credential) {
+      credential.status = 'official';
+    }
+    return credential;
+  }
+
+  getCredential(id: string): Credential | undefined {
+    return this.credentials.get(id);
+  }
+
+  listProvisional(): Credential[] {
+    return Array.from(this.credentials.values()).filter(c => c.status === 'provisional');
+  }
+}
+
+export const credentialService = new CredentialService();


### PR DESCRIPTION
## Summary
- outline in-memory credential store with provisional and official statuses
- expose provisional VC helpers in controller
- document provisional VC support in README
- add Prisma schema draft for credential status
- include basic test demonstrating provisional workflow

## Testing
- `pytest -q` *(fails: SyntaxError in placeholder test_matcher.py)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d8a94cd1c832088bb7c297232c1c4