### PR TITLE
Add Fetch License button for integrated issuers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## New Features
+
+- Integrated issuers now have a **Fetch License** button on the credential page. This button calls a new API route and displays the license data when retrieved.

--- a/frontend/components/FetchLicenseButton.tsx
+++ b/frontend/components/FetchLicenseButton.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+interface FetchLicenseButtonProps {
+  issuerId: string;
+  onFetched?: (license: any) => void;
+}
+
+export default function FetchLicenseButton({ issuerId, onFetched }: FetchLicenseButtonProps) {
+  const [loading, setLoading] = useState(false);
+
+  const fetchLicense = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/license?issuerId=${issuerId}`);
+      const data = await res.json();
+      if (onFetched) {
+        onFetched(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch license', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button onClick={fetchLicense} disabled={loading}>
+      {loading ? 'Fetching…' : 'Fetch License'}
+    </button>
+  );
+}

--- a/frontend/pages/api/license.ts
+++ b/frontend/pages/api/license.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { issuerId } = req.query;
+  // Dummy license data for placeholder backend
+  const license = {
+    issuerId,
+    licenseNumber: `LIC-${issuerId}`,
+    status: 'active',
+  };
+  res.status(200).json(license);
+}

--- a/frontend/pages/credentials/[id].tsx
+++ b/frontend/pages/credentials/[id].tsx
@@ -1,1 +1,41 @@
-// [id].tsx - placeholder or stub for chai-vc-platform
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import FetchLicenseButton from '../../components/FetchLicenseButton';
+
+interface Credential {
+  id: string;
+  issuer: {
+    id: string;
+    name: string;
+    integrated: boolean;
+  };
+}
+
+export default function CredentialPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [license, setLicense] = useState<any>(null);
+
+  // Dummy credential data
+  const credential: Credential = {
+    id: (id as string) || 'unknown',
+    issuer: {
+      id: 'issuer1',
+      name: 'Sample Issuer',
+      integrated: true,
+    },
+  };
+
+  return (
+    <div>
+      <h1>Credential {credential.id}</h1>
+      <p>Issuer: {credential.issuer.name}</p>
+      {credential.issuer.integrated && (
+        <FetchLicenseButton issuerId={credential.issuer.id} onFetched={setLicense} />
+      )}
+      {license && (
+        <pre data-testid="license-data">{JSON.stringify(license, null, 2)}</pre>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a FetchLicenseButton React component
- create an API route to return dummy license data
- update the credential page to show the button for integrated issuers
- document the new feature in the README

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `pytest` *(fails: SyntaxError in placeholder test)*

------
https://chatgpt.com/codex/tasks/task_e_686d8aa6911483209e2a3c9963a2925d