### PR TITLE
Implement error handling UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Error Handling UI
+
+The frontend now includes basic logic for displaying errors when API requests hit
+rate limits (HTTP 429) or time out after five seconds. Errors are presented in a
+styled `ErrorDisplay` component.

--- a/frontend/components/ErrorDisplay.tsx
+++ b/frontend/components/ErrorDisplay.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+export interface ErrorDisplayProps {
+  title?: string;
+  message: string;
+}
+
+const containerStyle: React.CSSProperties = {
+  border: "1px solid red",
+  padding: "1rem",
+  backgroundColor: "#ffe6e6",
+  borderRadius: "4px",
+};
+
+const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ title = "Error", message }) => (
+  <div style={containerStyle}>
+    <h2>{title}</h2>
+    <p>{message}</p>
+  </div>
+);
+
+export default ErrorDisplay;

--- a/frontend/pages/credentials/[id].tsx
+++ b/frontend/pages/credentials/[id].tsx
@@ -1,1 +1,75 @@
-// [id].tsx - placeholder or stub for chai-vc-platform
+import { useRouter } from "next/router";
+import React, { useEffect, useState } from "react";
+import ErrorDisplay from "../../components/ErrorDisplay";
+
+interface CredentialData {
+  id: string;
+  // Additional fields would go here
+}
+
+const CredentialPage: React.FC = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const [data, setData] = useState<CredentialData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort();
+      setError("Request timed out. Please try again later.");
+      setLoading(false);
+    }, 5000);
+
+    fetch(`/api/credentials/${id}`, { signal: controller.signal })
+      .then((response) => {
+        if (response.status === 429) {
+          throw new Error(
+            "Rate limit exceeded. Please wait before retrying."
+          );
+        }
+        if (!response.ok) {
+          throw new Error("Failed to fetch credential data.");
+        }
+        return response.json();
+      })
+      .then((json) => {
+        clearTimeout(timeout);
+        setData(json as CredentialData);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (err.name === "AbortError") {
+          return; // timeout already handled
+        }
+        clearTimeout(timeout);
+        setError(err.message);
+        setLoading(false);
+      });
+
+    return () => {
+      clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [id]);
+
+  if (error) {
+    return <ErrorDisplay title="Unable to load credential" message={error} />;
+  }
+
+  if (loading) {
+    return <div>Loading credential...</div>;
+  }
+
+  return (
+    <div>
+      <h1>Credential {id}</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+};
+
+export default CredentialPage;


### PR DESCRIPTION
## Summary
- add ErrorDisplay component for showing API error messages
- fetch credential data with timeout and rate limit handling
- document the new behavior in the README

## Testing
- `pytest -q` *(fails: SyntaxError in placeholder test_matcher.py)*

------
https://chatgpt.com/codex/tasks/task_e_686d8ac751588320af85fdfc5626f63f