### PR TITLE
Implement VC issuance API

### DIFF
--- a/backend/src/blockchain/blockchain_integration.js
+++ b/backend/src/blockchain/blockchain_integration.js
@@ -1,0 +1,9 @@
+const crypto = require('crypto');
+
+async function anchorHashOnChain(hash) {
+  const txId = '0x' + crypto.randomBytes(16).toString('hex');
+  console.log(`Anchored hash ${hash} in tx ${txId}`);
+  return txId;
+}
+
+module.exports = { anchorHashOnChain };

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,0 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform

--- a/backend/src/controllers/credential_controller.js
+++ b/backend/src/controllers/credential_controller.js
@@ -1,0 +1,17 @@
+const crypto = require('crypto');
+
+const keyPair = crypto.generateKeyPairSync('ed25519');
+
+function signCredential(vc) {
+  const data = Buffer.from(JSON.stringify(vc));
+  const signature = crypto.sign(null, data, keyPair.privateKey);
+  const proof = {
+    type: 'Ed25519Signature2020',
+    created: new Date().toISOString(),
+    proofValue: signature.toString('base64'),
+    verificationMethod: 'did:example:issuer#key-1'
+  };
+  return { ...vc, proof };
+}
+
+module.exports = { signCredential };

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,0 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,32 @@
+const http = require('http');
+const { signCredential } = require('./controllers/credential_controller');
+const { anchorHashOnChain } = require('./blockchain/blockchain_integration');
+const crypto = require('crypto');
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/api/issue-vc') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', async () => {
+      try {
+        const credential = JSON.parse(body);
+        const signedVc = signCredential(credential);
+        const hash = crypto.createHash('sha256').update(JSON.stringify(signedVc)).digest('hex');
+        const txId = await anchorHashOnChain(hash);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ signedVc, txId }));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid credential or internal error' }));
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+server.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add simple Express-like server exposing `/api/issue-vc`
- sign credentials with an Ed25519 key
- simulate anchoring the credential hash on-chain

## Testing
- `node backend/src/server.js &` and issue request with curl

------
https://chatgpt.com/codex/tasks/task_e_686dcd4c12008320870b18f43c56bf44