### PR TITLE
Implement verifier search with GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## GraphQL Server
+
+Run `ts-node backend/src/graphql/clinician_resolver.ts` to start a simple GraphQL server. It exposes a `cliniciansBySpecialty` query returning clinicians filtered by specialty.
+
+The frontend `verifier-search` page demonstrates a basic UI calling this resolver.

--- a/backend/src/graphql/clinician_resolver.ts
+++ b/backend/src/graphql/clinician_resolver.ts
@@ -1,0 +1,40 @@
+import { ApolloServer, gql } from 'apollo-server-express';
+import express from 'express';
+
+const typeDefs = gql`
+  type Clinician {
+    id: ID!
+    name: String!
+    specialty: String!
+  }
+
+  type Query {
+    cliniciansBySpecialty(specialty: String!): [Clinician!]!
+  }
+`;
+
+const clinicians = [
+  { id: '1', name: 'Dr. Smith', specialty: 'Cardiology' },
+  { id: '2', name: 'Dr. Adams', specialty: 'Neurology' },
+  { id: '3', name: 'Dr. Brown', specialty: 'Cardiology' },
+];
+
+const resolvers = {
+  Query: {
+    cliniciansBySpecialty: (_: unknown, { specialty }: { specialty: string }) =>
+      clinicians.filter(
+        (c) => c.specialty.toLowerCase() === specialty.toLowerCase()
+      ),
+  },
+};
+
+export function startGraphQLServer(port = 4000) {
+  const app = express();
+  const server = new ApolloServer({ typeDefs, resolvers });
+  server.start().then(() => {
+    server.applyMiddleware({ app });
+    app.listen({ port }, () => {
+      console.log(`GraphQL ready at http://localhost:${port}${server.graphqlPath}`);
+    });
+  });
+}

--- a/backend/src/graphql/graphql_api_scaffold.ts
+++ b/backend/src/graphql/graphql_api_scaffold.ts
@@ -1,1 +1,6 @@
-// graphql_api_scaffold.ts - placeholder or stub for chai-vc-platform
+import { startGraphQLServer } from './clinician_resolver';
+
+// Start the GraphQL API when this module is executed directly
+if (require.main === module) {
+  startGraphQLServer();
+}

--- a/frontend/pages/verifier-search.tsx
+++ b/frontend/pages/verifier-search.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+interface Clinician {
+  id: string;
+  name: string;
+  specialty: string;
+}
+
+export default function VerifierSearch() {
+  const [specialty, setSpecialty] = useState('');
+  const [results, setResults] = useState<Clinician[]>([]);
+
+  async function search() {
+    const res = await fetch('/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: `query($spec: String!) {\n  cliniciansBySpecialty(specialty: $spec) {\n    id\n    name\n    specialty\n  }\n}`,
+        variables: { spec: specialty },
+      }),
+    });
+    const json = await res.json();
+    setResults(json.data.cliniciansBySpecialty);
+  }
+
+  return (
+    <div>
+      <h1>Verifier Search</h1>
+      <input
+        value={specialty}
+        onChange={(e) => setSpecialty(e.target.value)}
+        placeholder="Specialty"
+      />
+      <button onClick={search}>Search</button>
+      <ul>
+        {results.map((c) => (
+          <li key={c.id}>
+            {c.name} - {c.specialty}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose a GraphQL resolver that returns clinicians filtered by specialty
- scaffold a server entry point that starts the GraphQL API
- add a simple verifier search UI page
- document how to run the sample server

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686dcd781acc8320951ca2438536bb4a