### PR TITLE
Add prisma seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Backend database setup
+
+1. Install dependencies in the `backend` folder:
+
+```bash
+cd backend
+npm install
+```
+
+2. Set the `DATABASE_URL` environment variable to point to your PostgreSQL instance.
+
+3. Push the schema and seed the database:
+
+```bash
+npx prisma db push
+npm run seed
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "chai-backend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "seed": "ts-node prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.0.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,1 +1,32 @@
-// schema.prisma - placeholder or stub for chai-vc-platform
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Clinician {
+  id          String       @id @default(uuid())
+  firstName   String
+  lastName    String
+  credentials Credential[]
+}
+
+model Issuer {
+  id          String       @id @default(uuid())
+  name        String
+  credentials Credential[]
+}
+
+model Credential {
+  id          String    @id @default(uuid())
+  type        String
+  issuedAt    DateTime  @default(now())
+  clinician   Clinician @relation(fields: [clinicianId], references: [id])
+  clinicianId String
+  issuer      Issuer    @relation(fields: [issuerId], references: [id])
+  issuerId    String
+}
+

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,33 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const issuer = await prisma.issuer.create({
+    data: { name: 'General Hospital' }
+  });
+
+  const clinician = await prisma.clinician.create({
+    data: {
+      firstName: 'John',
+      lastName: 'Doe'
+    }
+  });
+
+  await prisma.credential.create({
+    data: {
+      type: 'Medical License',
+      clinicianId: clinician.id,
+      issuerId: issuer.id
+    }
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["prisma/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- define clinician, issuer, and credential models in Prisma
- add seed script to populate demo entries
- provide backend setup instructions
- include node configuration for Prisma

## Testing
- `npx prisma validate` *(fails: needs to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_686dcd823740832088807182ab946866