### PR TITLE
Add CI with lint, tests, and Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,1 +1,37 @@
-// ci.yml - placeholder or stub for chai-vc-platform
+name: CI
+
+on:
+  push:
+    branches: ["main", "work"]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install flake8
+      - run: flake8 ai-matcher-service
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install pytest
+      - run: pytest ai-matcher-service/tests
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build ai-matcher-service image
+        run: docker build -t ai-matcher-service ./ai-matcher-service
+      - name: Build backend image
+        run: docker build -t backend ./backend

--- a/ai-matcher-service/Dockerfile
+++ b/ai-matcher-service/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+CMD ["python", "-c", "print('ai-matcher-service placeholder')"]

--- a/ai-matcher-service/src/routes/match.py
+++ b/ai-matcher-service/src/routes/match.py
@@ -1,1 +1,1 @@
-// match.py - placeholder or stub for chai-vc-platform
+# match.py - placeholder or stub for chai-vc-platform

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY . .
+CMD ["node", "-e", "console.log('backend placeholder')"]


### PR DESCRIPTION
## Summary
- create GitHub Actions workflow running lint, pytest and Docker builds
- add basic Dockerfiles for backend and ai matcher service
- fix placeholder Python files so lint passes

## Testing
- `flake8 ai-matcher-service`
- `pytest -q`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dcde98b1483209fe0bffd09922893