### PR TITLE
Add Helm charts for monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Monitoring
+
+Helm configuration for deploying Prometheus and Grafana is available
+under [`k8s/monitoring`](k8s/monitoring). Follow the instructions in that
+directory to install the `kube-prometheus-stack` chart and enable
+cluster monitoring.

--- a/k8s/monitoring/README.md
+++ b/k8s/monitoring/README.md
@@ -1,0 +1,24 @@
+# Cluster Monitoring
+
+This directory contains a minimal Helm configuration for deploying
+[kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
+which provides Prometheus, Grafana and Alertmanager.
+
+## Prerequisites
+
+- A running Kubernetes cluster
+- Helm v3 installed
+
+## Installation
+
+Add the Prometheus Community Helm repository and install the chart:
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+helm upgrade --install monitoring prometheus-community/kube-prometheus-stack \
+  -f prometheus-grafana-values.yaml
+```
+
+By default the services are exposed as `NodePort`. Adjust the values in
+`prometheus-grafana-values.yaml` for your environment.

--- a/k8s/monitoring/prometheus-grafana-values.yaml
+++ b/k8s/monitoring/prometheus-grafana-values.yaml
@@ -1,0 +1,15 @@
+# Helm values for kube-prometheus-stack
+# Exposes Prometheus, Grafana and Alertmanager via NodePort services
+# Adjust service types and persistence settings for production use
+
+alertmanager:
+  service:
+    type: NodePort
+
+prometheus:
+  service:
+    type: NodePort
+
+grafana:
+  service:
+    type: NodePort


### PR DESCRIPTION
## Summary
- add Prometheus/Grafana Helm configuration under `k8s/monitoring`
- document how to install the monitoring stack
- update main README with monitoring section

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e447affd883208a6debc1bd558791