### PR TITLE
Add monitoring stack with Grafana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+*.log
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Monitoring Stack
+
+A lightweight monitoring setup is provided under `monitoring/`. It uses Prometheus
+and Grafana to visualise backend metrics such as block time and API latency.
+
+### Running the Backend
+
+```
+cd backend
+npm install
+npm start
+```
+
+By default the backend exposes metrics on `http://localhost:3000/metrics`.
+
+### Running Grafana and Prometheus
+
+```
+docker compose -f monitoring/docker-compose.monitoring.yml up
+```
+
+Prometheus will be available on `http://localhost:9090` and Grafana on
+`http://localhost:3000` (default credentials: `admin`/`admin`). The stack expects
+the backend to expose Prometheus metrics at `http://backend:3000/metrics`.
+
+The Grafana dashboard located at
+`monitoring/grafana/dashboards/blocktime_api_latency.json` will be automatically
+loaded.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "src/server.ts",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "start": "node --loader ts-node/esm src/server.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "prom-client": "^14.1.1",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,42 @@
+import express from 'express';
+import client from 'prom-client';
+
+const app = express();
+const collectDefaultMetrics = client.collectDefaultMetrics;
+collectDefaultMetrics();
+
+// Histogram to track request duration
+export const httpRequestDurationSeconds = new client.Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'HTTP request duration in seconds',
+  buckets: [0.1, 0.3, 0.5, 1, 1.5, 2, 5]
+});
+
+// Gauge for blockchain block time
+export const blockTimeSeconds = new client.Gauge({
+  name: 'block_time_seconds',
+  help: 'Latest blockchain block time in seconds'
+});
+
+app.use((req, res, next) => {
+  const end = httpRequestDurationSeconds.startTimer();
+  res.on('finish', () => end());
+  next();
+});
+
+app.get('/metrics', async (req, res) => {
+  res.set('Content-Type', client.register.contentType);
+  res.end(await client.register.metrics());
+});
+
+// Example endpoint that updates blockTimeSeconds
+app.get('/update-block', (_req, res) => {
+  const blockTime = Math.random() * 10; // placeholder value
+  blockTimeSeconds.set(blockTime);
+  res.json({ blockTime });
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - '9090:9090'
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - '3000:3000'
+    volumes:
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+    depends_on:
+      - prometheus

--- a/monitoring/grafana/dashboards/blocktime_api_latency.json
+++ b/monitoring/grafana/dashboards/blocktime_api_latency.json
@@ -1,0 +1,44 @@
+{
+  "uid": "blocktime-api-latency",
+  "title": "Block Time & API Latency",
+  "timezone": "browser",
+  "schemaVersion": 30,
+  "version": 1,
+  "refresh": "5s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Block Time (s)",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "block_time_seconds",
+          "legendFormat": "block_time_seconds"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "type": "timeseries",
+      "title": "API Latency (ms)",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) * 1000",
+          "legendFormat": "p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yaml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+dashboardProviders:
+  - name: 'default'
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/datasource.yaml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: 'backend'
+    static_configs:
+      - targets: ['backend:3000']


### PR DESCRIPTION
## Summary
- add a basic Express server exposing Prometheus metrics
- provide Grafana dashboard for block time and API latency
- provision Grafana and Prometheus via docker compose
- document how to run the monitoring stack

## Testing
- `npm install` *(passed)*
- `npm start` *(server ran)*
- `node -v`
- `docker compose -f monitoring/docker-compose.monitoring.yml config` *(failed: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4489dfc483208ba8804be8b77acd