### PR TITLE
Add bulk issue test data generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Test Data Generation
+
+A placeholder CLI script is provided in `scripts/bulk_issue.ts` for generating sample credential data. It outputs an array of JSON objects. Run it with `ts-node` and provide an optional count:
+
+```bash
+npx ts-node scripts/bulk_issue.ts 5
+```
+
+This will print five demo credential records to `stdout`.

--- a/scripts/bulk_issue.ts
+++ b/scripts/bulk_issue.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env ts-node
+
+// bulk_issue.ts - placeholder CLI script for generating test credential issue data for chai-vc-platform
+
+interface Credential {
+  id: number;
+  name: string;
+}
+
+function generateCredentials(count: number): Credential[] {
+  const creds: Credential[] = [];
+  for (let i = 0; i < count; i++) {
+    creds.push({
+      id: i + 1,
+      name: `Test Credential ${i + 1}`,
+    });
+  }
+  return creds;
+}
+
+const arg = process.argv[2];
+const count = arg ? parseInt(arg, 10) : 10;
+const data = generateCredentials(count);
+console.log(JSON.stringify(data, null, 2));
+


### PR DESCRIPTION
## Summary
- add `bulk_issue.ts` script to generate placeholder credential data
- document script usage in README

## Testing
- `node -e "require('fs').existsSync('scripts/bulk_issue.ts') && console.log('found')"`


------
https://chatgpt.com/codex/tasks/task_e_686e44a961f08320814cd0f710843f65