### PR TITLE
Add SNARK verifier runtime stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Blockchain Integration
+
+The `backend/src/blockchain` directory includes a stub implementation of an
+on-chain proof verification flow. The new `verifySelectiveProofRuntime` method
+loads a Snark verifier WebAssembly module and executes its exported
+`verify_selective_proof` function.

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,8 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { verify_selective_proof, SelectiveProof } from './snark_verifier';
+
+export async function verifyProofOnChain(
+  wasmPath: string,
+  selectiveProof: SelectiveProof
+): Promise<boolean> {
+  return verify_selective_proof(wasmPath, selectiveProof);
+}

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,9 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+import { verifyProofOnChain, SelectiveProof } from './blockchain_integration';
+
+export async function verifySelectiveProofRuntime(
+  wasmPath: string,
+  proof: SelectiveProof
+): Promise<boolean> {
+  // In a real polkadot runtime, this would invoke the on-chain method.
+  return verifyProofOnChain(wasmPath, proof);
+}

--- a/backend/src/blockchain/snark_verifier.ts
+++ b/backend/src/blockchain/snark_verifier.ts
@@ -1,0 +1,24 @@
+import fs from 'fs/promises';
+
+export interface SelectiveProof {
+  proof: Uint8Array;
+  publicInputs: Uint8Array;
+}
+
+export async function verify_selective_proof(
+  wasmPath: string,
+  selectiveProof: SelectiveProof
+): Promise<boolean> {
+  const wasmBuffer = await fs.readFile(wasmPath);
+  const wasmModule = await WebAssembly.instantiate(wasmBuffer, {});
+
+  const verifier = (wasmModule.instance.exports as any).verify_selective_proof;
+  if (typeof verifier !== 'function') {
+    throw new Error('verify_selective_proof function missing in WASM');
+  }
+
+  // Actual memory management is omitted in this stub implementation.
+  const result = verifier();
+
+  return !!result;
+}


### PR DESCRIPTION
## Summary
- implement a WASM-based `verify_selective_proof` stub
- wire `verifyProofOnChain` and `verifySelectiveProofRuntime` helpers
- document the new runtime method

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e450bebb88320958703aa1e50fb75