### PR TITLE
Add credential status background job

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Background Job
+
+The `backend/src/jobs/credential_status_job.ts` file contains a simple background
+job that connects to a Polkadot node and updates credential status on-chain.
+This job uses the `PolkadotService` to submit a `credentials.setStatus`
+extrinsic for each credential record.

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,14 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { PolkadotService } from './polkadot_service';
+
+// Simple facade used by other parts of the backend to interact with the chain
+export class BlockchainIntegration {
+  private service = new PolkadotService();
+
+  async init(endpoint: string): Promise<void> {
+    await this.service.connect(endpoint);
+  }
+
+  async setCredentialStatus(id: string, status: string): Promise<void> {
+    await this.service.updateCredentialStatus(id, status);
+  }
+}

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,26 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+import { ApiPromise, WsProvider, Keyring } from '@polkadot/api';
+
+export class PolkadotService {
+  private api: ApiPromise | null = null;
+
+  async connect(endpoint: string): Promise<void> {
+    const provider = new WsProvider(endpoint);
+    this.api = await ApiPromise.create({ provider });
+    await this.api.isReady;
+  }
+
+  async updateCredentialStatus(id: string, status: string): Promise<void> {
+    if (!this.api) throw new Error('API not initialized');
+
+    const keyring = new Keyring({ type: 'sr25519' });
+    const account = keyring.addFromUri(process.env.POLKADOT_SEED || '//Alice');
+
+    // In a real implementation, credentials pallet would expose setStatus
+    const tx = (this.api.tx as any).credentials?.setStatus(id, status);
+    if (!tx) {
+      throw new Error('credentials.setStatus extrinsic not available');
+    }
+
+    await tx.signAndSend(account);
+  }
+}

--- a/backend/src/jobs/credential_status_job.ts
+++ b/backend/src/jobs/credential_status_job.ts
@@ -1,0 +1,34 @@
+import { PolkadotService } from '../blockchain/polkadot_service';
+
+export interface CredentialRecord {
+  id: string;
+  status: string;
+}
+
+// Simple background job that updates credentials on the blockchain
+export async function runCredentialStatusJob(credentials: CredentialRecord[]) {
+  const service = new PolkadotService();
+  const endpoint = process.env.POLKADOT_ENDPOINT || 'ws://localhost:9944';
+  await service.connect(endpoint);
+
+  for (const credential of credentials) {
+    await service.updateCredentialStatus(credential.id, credential.status);
+  }
+}
+
+if (require.main === module) {
+  const sampleCredentials: CredentialRecord[] = [
+    { id: 'cred-1', status: 'Issued' },
+    { id: 'cred-2', status: 'Revoked' },
+  ];
+
+  runCredentialStatusJob(sampleCredentials)
+    .then(() => {
+      console.log('Credential status job completed');
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error('Credential status job failed', err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- scaffold a `PolkadotService` with a method to send `credentials.setStatus`
- add `BlockchainIntegration` facade
- implement `credential_status_job` that runs the background job
- document the new job in README

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest` *(fails: SyntaxError in placeholder test file)*

------
https://chatgpt.com/codex/tasks/task_e_686e45782de48320bd7d1b2f6a317efb