### PR TITLE
Add DIDComm v2 envelope helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## DIDComm v2 Envelope Support
+
+The backend now includes helper functions for creating and
+processing DIDComm v2 envelopes using [Aries‑Framework‑JS](https://github.com/hyperledger/aries-framework-javascript).
+The implementation lives in `backend/src/didcomm/didcomm_v2_envelope.ts` and
+exposes two functions:
+
+- `packDidCommV2Message` – packs a plaintext message into a DIDComm v2 JWE envelope.
+- `unpackDidCommV2Message` – decrypts an envelope back to the plaintext payload.
+
+These helpers spin up a lightweight Aries agent internally so they can be used
+without a running agent instance.

--- a/backend/src/didcomm/didcomm_v2_envelope.ts
+++ b/backend/src/didcomm/didcomm_v2_envelope.ts
@@ -1,0 +1,60 @@
+import type { PlaintextMessage, EncryptedMessage } from '@credo-ts/didcomm'
+import { Agent, getDefaultDidcommModules, EnvelopeService } from '@credo-ts/didcomm'
+import { agentDependencies } from '@credo-ts/node'
+
+export interface DidCommV2EnvelopeKeys {
+  recipientKeys: string[]
+  routingKeys?: string[]
+  senderKey?: string
+}
+
+/**
+ * Pack a DIDComm v2 message using Aries-Framework-JS.
+ * This sets up a temporary agent and uses the EnvelopeService
+ * to create a DIDComm v2 JWE envelope.
+ */
+export async function packDidCommV2Message(
+  message: PlaintextMessage,
+  keys: DidCommV2EnvelopeKeys
+): Promise<EncryptedMessage> {
+  const agent = new Agent({
+    config: { label: 'didcomm-v2-helper' },
+    dependencies: agentDependencies,
+    modules: getDefaultDidcommModules(),
+  })
+
+  await agent.initialize()
+
+  const envelopeService = agent.dependencyManager.resolve(EnvelopeService)
+  const encrypted = await envelopeService.packMessage(agent.context, message, {
+    recipientKeys: keys.recipientKeys.map((key) => ({ kid: key } as any)),
+    routingKeys: (keys.routingKeys ?? []).map((key) => ({ kid: key } as any)),
+    senderKey: keys.senderKey ? ({ kid: keys.senderKey } as any) : null,
+  })
+
+  await agent.shutdown()
+  return encrypted
+}
+
+/**
+ * Unpack a DIDComm v2 message using Aries-Framework-JS.
+ * The function creates a temporary agent to decrypt the envelope.
+ */
+export async function unpackDidCommV2Message(
+  envelope: EncryptedMessage,
+  keys: DidCommV2EnvelopeKeys
+): Promise<PlaintextMessage> {
+  const agent = new Agent({
+    config: { label: 'didcomm-v2-helper' },
+    dependencies: agentDependencies,
+    modules: getDefaultDidcommModules(),
+  })
+
+  await agent.initialize()
+
+  const envelopeService = agent.dependencyManager.resolve(EnvelopeService)
+  const decrypted = await envelopeService.unpackMessage(agent.context, envelope)
+
+  await agent.shutdown()
+  return decrypted.plaintextMessage
+}


### PR DESCRIPTION
## Summary
- implement helper functions for packing and unpacking DIDComm v2 envelopes using Aries‑Framework‑JS
- document DIDComm v2 support in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e48d5ee0c8320b14afa5591faadec