### PR TITLE
Add AWS KMS signer adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## AWS KMS Signer Adapter
+
+A simple adapter is provided under `backend/src/blockchain/aws_kms_adapter.ts` for signing payloads using AWS KMS. It relies on the AWS SDK v3 and expects a `region` and `keyId` during construction.

--- a/backend/src/blockchain/aws_kms_adapter.ts
+++ b/backend/src/blockchain/aws_kms_adapter.ts
@@ -1,0 +1,30 @@
+import { KMSClient, SignCommand } from "@aws-sdk/client-kms";
+
+export class AwsKmsSigner {
+  private kmsClient: KMSClient;
+  private keyId: string;
+
+  constructor(region: string, keyId: string) {
+    this.kmsClient = new KMSClient({ region });
+    this.keyId = keyId;
+  }
+
+  /**
+   * Sign a buffer of data using AWS KMS
+   * @param data Buffer containing data to sign
+   * @returns Signature as Buffer
+   */
+  async sign(data: Buffer): Promise<Buffer> {
+    const command = new SignCommand({
+      KeyId: this.keyId,
+      Message: data,
+      MessageType: "RAW",
+      SigningAlgorithm: "RSASSA_PKCS1_V1_5_SHA256",
+    });
+    const response = await this.kmsClient.send(command);
+    if (!response.Signature) {
+      throw new Error("KMS did not return a signature");
+    }
+    return Buffer.from(response.Signature as Uint8Array);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `AwsKmsSigner` for signing payloads via AWS KMS
- document the new adapter in the README

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e79facad08320951328f379ce84ab