### PR TITLE
Configure vc_issue_duration alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Monitoring
+
+A minimal Prometheus stack is included to demonstrate alerting on
+`vc_issue_duration_seconds`. The alert fires when the metric exceeds `2`
+for more than one minute and sends a notification to Slack via Alertmanager.
+
+### Running locally
+
+Set a `SLACK_WEBHOOK_URL` environment variable and start the services:
+
+```bash
+docker-compose up -d prometheus alertmanager
+```
+
+Prometheus will load `monitoring/alert_rules.yml` and Alertmanager will
+use `monitoring/alertmanager.yml` for Slack routing.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,1 +1,24 @@
-# docker-compose.yml - placeholder
+version: '3'
+services:
+  backend:
+    image: node:18
+    # Placeholder for backend service
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./monitoring/alert_rules.yml:/etc/prometheus/alert_rules.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - "9090:9090"
+  alertmanager:
+    image: prom/alertmanager
+    environment:
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/config.yml
+    command:
+      - '--config.file=/etc/alertmanager/config.yml'
+    ports:
+      - "9093:9093"

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -1,0 +1,11 @@
+groups:
+- name: vc_rules
+  rules:
+  - alert: VCIssueSlow
+    expr: vc_issue_duration_seconds > 2
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: VC issuance latency high
+      description: vc_issue_duration_seconds has exceeded 2 seconds

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,9 @@
+route:
+  receiver: slack-notifications
+
+receivers:
+- name: slack-notifications
+  slack_configs:
+  - api_url: ${SLACK_WEBHOOK_URL}
+    channel: '#alerts'
+    send_resolved: true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'backend'
+    static_configs:
+      - targets: ['backend:3000']
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
+rule_files:
+  - 'alert_rules.yml'


### PR DESCRIPTION
## Summary
- set up Prometheus and Alertmanager configs
- add alert rule for `vc_issue_duration_seconds > 2`
- wire Docker compose services for Prometheus and Alertmanager
- document how to run the monitoring stack

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e7a42f17c832099ced5b1e522a765