### PR TITLE
Implement HRIS webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Webhook Integration
+
+The backend exposes utilities to push newly hired clinicians to a hospital HRIS system.
+Set the environment variable `HRIS_WEBHOOK_URL` to the target webhook endpoint. When
+`hireClinician` is called, clinician details are POSTed to this URL as JSON.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/backend/__tests__/full_end_to_end_test.js
+++ b/backend/__tests__/full_end_to_end_test.js
@@ -1,0 +1,1 @@
+// full_end_to_end_test.js - placeholder or stub for chai-vc-platform

--- a/backend/__tests__/full_end_to_end_test.ts
+++ b/backend/__tests__/full_end_to_end_test.ts
@@ -1,1 +1,0 @@
-// full_end_to_end_test.ts - placeholder or stub for chai-vc-platform

--- a/backend/__tests__/hris_webhook.test.js
+++ b/backend/__tests__/hris_webhook.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const { createServer } = require('http');
+const { sendClinicianToHRIS } = require('../src/hris/hris_webhook');
+
+async function run() {
+  const clinician = { id: '1', name: 'Alice', role: 'RN' };
+
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      try {
+        assert.strictEqual(req.method, 'POST');
+        assert.strictEqual(req.headers['content-type'], 'application/json');
+        const data = JSON.parse(body);
+        assert.deepStrictEqual(data, clinician);
+        res.statusCode = 200;
+        res.end('ok');
+      } finally {
+        server.close();
+      }
+    });
+  });
+
+  await new Promise(resolve => server.listen(3456, resolve));
+  process.env.HRIS_WEBHOOK_URL = 'http://localhost:3456/';
+  await sendClinicianToHRIS(clinician);
+}
+
+run();

--- a/backend/src/controllers/credential_controller.js
+++ b/backend/src/controllers/credential_controller.js
@@ -1,0 +1,12 @@
+const { sendClinicianToHRIS } = require('../hris/hris_webhook');
+
+/**
+ * Hire a clinician and push their details to the hospital HRIS.
+ * @param {{id: string, name: string, role: string}} clinician
+ */
+async function hireClinician(clinician) {
+  // Placeholder for additional business logic such as credential checks.
+  await sendClinicianToHRIS(clinician);
+}
+
+module.exports = { hireClinician };

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,0 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform

--- a/backend/src/hris/hris_webhook.js
+++ b/backend/src/hris/hris_webhook.js
@@ -1,0 +1,42 @@
+const { request } = require('http');
+
+/**
+ * Send hired clinician details to the hospital HRIS webhook.
+ * @param {{id: string, name: string, role: string}} clinician
+ */
+function sendClinicianToHRIS(clinician) {
+  const url = process.env.HRIS_WEBHOOK_URL;
+  if (!url) {
+    return Promise.reject(new Error('HRIS_WEBHOOK_URL not set'));
+  }
+
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const data = JSON.stringify(clinician);
+
+    const options = {
+      hostname: parsed.hostname,
+      port: parsed.port || 80,
+      path: parsed.pathname,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(data)
+      }
+    };
+
+    const req = request(options, res => {
+      if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+        resolve();
+      } else {
+        reject(new Error(`HRIS webhook responded with status ${res.statusCode}`));
+      }
+    });
+
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+module.exports = { sendClinicianToHRIS };


### PR DESCRIPTION
## Summary
- add ability to push hired clinician details to HRIS via webhook
- document the HRIS webhook env var
- add basic tests and convert old stubs from TypeScript to JavaScript/Python

## Testing
- `node backend/__tests__/hris_webhook.test.js`
- `python ai-matcher-service/tests/test_matcher.py`


------
https://chatgpt.com/codex/tasks/task_e_686ec5cf2ef08320a66bfdb74f8b9ee2