### PR TITLE
Add Grant Privileges demo with stub VC issuance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Grant Privileges Demo
+
+A minimal Express server is provided in `backend/src/server.ts`. It exposes a `/grant-privileges` endpoint that writes a stub employment-offer VC to `employment_offer_vc.json` and appends a hire event to `hire_events.log`.
+
+The frontend page `frontend/pages/grant-privileges.tsx` contains a button that calls this endpoint. Run the server with `node backend/src/server.ts` and visit the page to trigger VC issuance.

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,27 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+
+const app = express();
+app.use(express.json());
+
+app.post('/grant-privileges', (req, res) => {
+  const subject = req.body?.subject || 'placeholder-subject';
+  const vc = {
+    type: 'EmploymentOfferCredential',
+    issued: new Date().toISOString(),
+    subject,
+  };
+
+  const vcPath = path.join(__dirname, '../../employment_offer_vc.json');
+  fs.writeFileSync(vcPath, JSON.stringify(vc, null, 2));
+
+  const logPath = path.join(__dirname, '../../hire_events.log');
+  fs.appendFileSync(logPath, `Hire event for ${subject} at ${vc.issued}\n`);
+
+  res.json({ status: 'issued', vc });
+});
+
+app.listen(3001, () => {
+  console.log('Backend server running on port 3001');
+});

--- a/frontend/pages/grant-privileges.tsx
+++ b/frontend/pages/grant-privileges.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+
+export default function GrantPrivileges() {
+  const [message, setMessage] = useState('');
+
+  async function handleClick() {
+    const res = await fetch('http://localhost:3001/grant-privileges', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subject: 'user123' }),
+    });
+    const data = await res.json();
+    setMessage(`VC issued at ${data.vc.issued}`);
+  }
+
+  return (
+    <div>
+      <h1>Grant Privileges</h1>
+      <button onClick={handleClick}>Grant Privileges</button>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add basic Express server with `/grant-privileges` endpoint
- log hire events and save stub employment offer VCs
- add frontend page with **Grant Privileges** button
- document demo setup in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ec5d770c88320b9f595e579cfbb37