### PR TITLE
Add OpenTelemetry tracing stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Tracing
+
+Both the backend and matcher services include simple OpenTelemetry configuration. Spans are exported to the console so requests through the API, matcher, and blockchain stubs can be traced when the services are executed.

--- a/ai-matcher-service/src/routes/match.py
+++ b/ai-matcher-service/src/routes/match.py
@@ -1,1 +1,12 @@
-// match.py - placeholder or stub for chai-vc-platform
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, ConsoleSpanExporter
+
+trace.set_tracer_provider(TracerProvider())
+tracer = trace.get_tracer(__name__)
+trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+def run_match(data: dict) -> dict:
+    with tracer.start_as_current_span("run_match"):
+        # matcher logic placeholder
+        return {"matched": True}

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,10 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from routes.match import run_match
+
+
+def test_run_match():
+    assert run_match({}) == {"matched": True}

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,11 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { tracer } from '../tracing';
+import { submitToChain } from './polkadot_service';
+
+export async function storeCredential(data: string): Promise<{ block: number }> {
+  const span = tracer.startSpan('storeCredential');
+  try {
+    return await submitToChain(data);
+  } finally {
+    span.end();
+  }
+}

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,11 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+import { tracer } from '../tracing';
+
+export async function submitToChain(data: string): Promise<{ block: number }> {
+  const span = tracer.startSpan('submitToChain');
+  try {
+    // blockchain interaction placeholder
+    return { block: 1 };
+  } finally {
+    span.end();
+  }
+}

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,12 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { Request, Response } from 'express';
+import { tracer } from '../tracing';
+
+export async function issueCredential(req: Request, res: Response): Promise<void> {
+  const span = tracer.startSpan('issueCredential');
+  try {
+    // business logic placeholder
+    res.json({ status: 'issued' });
+  } finally {
+    span.end();
+  }
+}

--- a/backend/src/tracing.ts
+++ b/backend/src/tracing.ts
@@ -1,0 +1,12 @@
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { trace } from '@opentelemetry/api';
+
+const provider = new NodeTracerProvider();
+provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+provider.register();
+
+registerInstrumentations({ instrumentations: [] });
+
+export const tracer = trace.getTracer('chai-vc-platform');


### PR DESCRIPTION
## Summary
- set up OpenTelemetry tracing for the backend
- instrument credential controller and blockchain services
- instrument matcher service with OpenTelemetry
- document tracing configuration
- add basic matcher unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec606826483209b6591ab2146633e