### PR TITLE
Add runbooks for node crash, API outage, and DB failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+Operational runbooks are available in the `runbooks/` directory.

--- a/runbooks/api-outage.md
+++ b/runbooks/api-outage.md
@@ -1,0 +1,25 @@
+# API Outage
+
+This runbook outlines steps to resolve an unexpected API outage.
+
+1. **Confirm the outage**
+   - Check monitoring dashboards and logs to verify errors.
+   - Determine whether the outage affects all users or a subset.
+2. **Gather logs and metrics**
+   - Inspect pod logs for stack traces or error messages:
+     ```bash
+     kubectl logs deployment/backend
+     ```
+   - Review recent deployments or configuration changes that may have triggered the issue.
+3. **Roll back or redeploy**
+   - If a recent deployment is suspected, roll back to the previous stable version:
+     ```bash
+     kubectl rollout undo deployment/backend
+     ```
+   - Alternatively, redeploy the current version to clear transient issues:
+     ```bash
+     kubectl rollout restart deployment/backend
+     ```
+4. **Verify recovery**
+   - Monitor API health endpoints until successful responses return.
+   - Notify stakeholders once the API is stable.

--- a/runbooks/db-failover.md
+++ b/runbooks/db-failover.md
@@ -1,0 +1,19 @@
+# DB Failover
+
+This runbook explains how to fail over to a standby database instance.
+
+1. **Assess the primary DB**
+   - Confirm that the primary database is unavailable or degraded.
+   - Check replication status and timestamps on the standby.
+2. **Promote the standby**
+   - Use the database tooling to promote the replica.
+     Example for PostgreSQL with Patroni:
+     ```bash
+     patronictl switchover --master <failed-node> --candidate <standby-node>
+     ```
+   - Update any load balancer or connection strings to point to the new primary.
+3. **Restart dependent services**
+   - Restart application pods or services that maintain persistent DB connections.
+4. **Monitor and verify**
+   - Ensure new writes succeed on the promoted node.
+   - Plan to rebuild or re-sync the original primary before reintroducing it.

--- a/runbooks/node-crash.md
+++ b/runbooks/node-crash.md
@@ -1,0 +1,22 @@
+# Node Crash
+
+This runbook describes how to recover from a crashed node.
+
+1. **Identify the issue**
+   - Check monitoring alerts for node status.
+   - Verify whether the node is unreachable via SSH or Kubernetes.
+2. **Drain and cordon**
+   - If using Kubernetes, cordon the node to prevent new pods from scheduling:
+     ```bash
+     kubectl cordon <node-name>
+     ```
+   - Drain running workloads if possible:
+     ```bash
+     kubectl drain <node-name> --ignore-daemonsets --delete-emptydir-data
+     ```
+3. **Restart or replace**
+   - Attempt to reboot the node via the cloud provider console or infrastructure tools.
+   - If the node does not come back, provision a new node and remove the old one from the cluster.
+4. **Restore services**
+   - Verify pods reschedule to healthy nodes.
+   - Monitor application logs to ensure normal operation resumes.


### PR DESCRIPTION
## Summary
- add runbooks for node crashes, API outages, and DB failover procedures
- mention the runbooks folder in README

## Testing
- `pytest -q` *(fails: SyntaxError in placeholder test)*

------
https://chatgpt.com/codex/tasks/task_e_68727483fabc832086c9774365d6ed52