### PR TITLE
Add Dilithium signing module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+backend/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+This repo now includes a Dilithium-based signature module for
+signing Verifiable Credentials using post-quantum cryptography.
+The implementation lives in `backend/src/crypto/dilithium_signer.js`
+and is tested via `backend/tests/dilithium_signer.test.js`.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "backend",
+      "version": "1.0.0",
+      "dependencies": {
+        "@red_pandas/pq-js": "^1.0.2"
+      }
+    },
+    "node_modules/@red_pandas/pq-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@red_pandas/pq-js/-/pq-js-1.0.2.tgz",
+      "integrity": "sha512-k3LBn4Ry/Uw3Mb02obVagSpVWWMje0hqO+rEQf/zzCeha/uhehLlhK9IMYkGJo0uemQleKHJhprYxrUroIoaAA==",
+      "license": "MIT",
+      "bin": {
+        "pq-js": "dist/cli.js"
+      }
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "commonjs",
+  "dependencies": {
+    "@red_pandas/pq-js": "^1.0.2"
+  }
+}

--- a/backend/src/crypto/dilithium_signer.js
+++ b/backend/src/crypto/dilithium_signer.js
@@ -1,0 +1,33 @@
+const { initDilithium, cleanupDilithium } = require('@red_pandas/pq-js');
+
+class DilithiumSigner {
+  constructor() {
+    this.wrapper = null;
+    this.ready = initDilithium().then(wrappers => {
+      this.wrapper = wrappers.dilithium2; // use Dilithium2 by default
+    });
+  }
+
+  async generateKeypair() {
+    await this.ready;
+    return this.wrapper.generateKeypair();
+  }
+
+  async sign(message, secretKey) {
+    await this.ready;
+    const msgBytes = typeof message === 'string' ? Buffer.from(message) : message;
+    return this.wrapper.sign(msgBytes, secretKey);
+  }
+
+  async verify(message, signature, publicKey) {
+    await this.ready;
+    const msgBytes = typeof message === 'string' ? Buffer.from(message) : message;
+    return this.wrapper.verify(msgBytes, signature, publicKey);
+  }
+
+  close() {
+    cleanupDilithium();
+  }
+}
+
+module.exports = { DilithiumSigner };

--- a/backend/tests/dilithium_signer.test.js
+++ b/backend/tests/dilithium_signer.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { DilithiumSigner } = require('../src/crypto/dilithium_signer');
+
+(async () => {
+  const signer = new DilithiumSigner();
+  const { publicKey, secretKey } = await signer.generateKeypair();
+  const message = 'test message';
+  const signature = await signer.sign(message, secretKey);
+  assert.ok(signature.length > 0, 'signature should not be empty');
+  const valid = await signer.verify(message, signature, publicKey);
+  signer.close();
+  assert.ok(valid, 'signature should verify');
+  console.log('Dilithium signing test passed');
+})();


### PR DESCRIPTION
## Summary
- add npm package manifest for backend
- implement Dilithium signer using `@red_pandas/pq-js`
- test signing and verification
- document Dilithium signer in README

## Testing
- `npm install` in backend
- `node tests/dilithium_signer.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687274b9052483208d174f8e5ecfe8b2