### PR TITLE
Add runtime flag for PQ signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Signature transition flag
+
+Set the environment variable `ACCEPT_PQ_SIGS=true` to allow the backend to accept
+both traditional ECDSA signatures and post-quantum (PQ) signatures during the
+migration period. When unset or set to any other value, only ECDSA signatures
+are accepted.

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,0 +1,1 @@
+export const ACCEPT_PQ_SIGS = process.env.ACCEPT_PQ_SIGS === 'true';

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,14 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { ACCEPT_PQ_SIGS } from '../config';
+
+/**
+ * Determines whether a given signature type is accepted.
+ * ECDSA signatures are always accepted. Post-quantum (PQ)
+ * signatures are conditionally accepted when the
+ * `ACCEPT_PQ_SIGS` environment variable is set to "true".
+ */
+export function isSignatureAllowed(type: 'ECDSA' | 'PQ'): boolean {
+  if (type === 'PQ') {
+    return ACCEPT_PQ_SIGS;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- add `ACCEPT_PQ_SIGS` runtime flag
- document how to enable PQ signatures during transition
- implement signature check helper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68728fe1cb4c832081e7634334da6d06