### PR TITLE
Add monitoring service for monthly PSV refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Continuous Monitoring Service
+
+The repository includes a basic monitoring service that schedules a monthly
+Primary Source Verification (PSV) refresh. The service lives in
+`monitoring-service/continuous_monitoring.py` and can be executed directly:
+
+```bash
+python monitoring-service/continuous_monitoring.py
+```
+
+It runs continuously and triggers the refresh logic on the first day of each
+month.

--- a/ai-matcher-service/src/routes/match.py
+++ b/ai-matcher-service/src/routes/match.py
@@ -1,1 +1,6 @@
-// match.py - placeholder or stub for chai-vc-platform
+"""Routes for the AI matcher service."""
+
+
+def match_endpoint() -> str:
+    """Placeholder match endpoint."""
+    return "match"

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,6 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+"""Placeholder tests for the AI matcher service."""
+
+
+def test_placeholder() -> None:
+    """Basic placeholder test to ensure pytest is configured."""
+    assert True

--- a/monitoring_service/continuous_monitoring.py
+++ b/monitoring_service/continuous_monitoring.py
@@ -1,0 +1,32 @@
+import datetime
+import logging
+import time
+
+logging.basicConfig(level=logging.INFO)
+
+
+def refresh_psv() -> None:
+    """Refresh Primary Source Verification records."""
+    logging.info("Refreshing PSV records")
+
+
+def check_and_run(current_time: datetime.datetime, last_run_month: int | None) -> int | None:
+    """Run refresh on the first day of the month."""
+    if current_time.day == 1 and current_time.month != last_run_month:
+        refresh_psv()
+        return current_time.month
+    return last_run_month
+
+
+def run_service() -> None:
+    """Start the continuous monitoring loop."""
+    logging.info("Continuous monitoring service started")
+    last_run: int | None = None
+    while True:
+        now = datetime.datetime.utcnow()
+        last_run = check_and_run(now, last_run)
+        time.sleep(86400)  # Check once per day
+
+
+if __name__ == "__main__":
+    run_service()

--- a/monitoring_service/tests/test_monitoring.py
+++ b/monitoring_service/tests/test_monitoring.py
@@ -1,0 +1,25 @@
+import datetime
+from unittest.mock import patch
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import monitoring_service.continuous_monitoring as cm
+
+
+def test_check_and_run_triggers_on_first_day() -> None:
+    month = None
+    with patch("monitoring_service.continuous_monitoring.refresh_psv") as mock_refresh:
+        month = cm.check_and_run(datetime.datetime(2025, 1, 1), month)
+        mock_refresh.assert_called_once()
+        assert month == 1
+
+
+def test_check_and_run_not_triggered_other_days() -> None:
+    month = None
+    with patch("monitoring_service.continuous_monitoring.refresh_psv") as mock_refresh:
+        month = cm.check_and_run(datetime.datetime(2025, 1, 2), month)
+        mock_refresh.assert_not_called()
+        assert month is None


### PR DESCRIPTION
## Summary
- create monitoring_service module with monthly PSV refresh logic
- add unit tests for monitoring service
- fix AI matcher placeholder modules
- document the monitoring service in the README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872900002f48320816e658b228fe376