### PR TITLE
Add pgcrypto setup for PII encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Database Encryption
+
+PII fields are encrypted at the column level using PostgreSQL's `pgcrypto` extension. The migration at `backend/prisma/migrations/001_enable_pgcrypto.sql` installs the extension, creates an example `users` table and sets up a trigger so that `email` and `ssn` values are symmetrically encrypted before insert or update.
+
+Before running the migration, set a database parameter for the encryption key, e.g.
+
+```sql
+ALTER SYSTEM SET app.encryption_key = 'replace-with-secure-key';
+SELECT pg_reload_conf();
+```
+
+Data can be decrypted in queries using `pgp_sym_decrypt`:
+
+```sql
+SELECT
+  id,
+  pgp_sym_decrypt(email, current_setting('app.encryption_key')) AS email,
+  pgp_sym_decrypt(ssn, current_setting('app.encryption_key')) AS ssn
+FROM users;
+```

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/backend/prisma/migrations/001_enable_pgcrypto.sql
+++ b/backend/prisma/migrations/001_enable_pgcrypto.sql
@@ -1,0 +1,23 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Example users table with PII encrypted at the column level
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    first_name TEXT NOT NULL,
+    last_name TEXT NOT NULL,
+    email BYTEA NOT NULL,
+    ssn BYTEA NOT NULL
+);
+
+-- Trigger to automatically encrypt PII columns using pgcrypto
+CREATE OR REPLACE FUNCTION encrypt_user_pii() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.email := pgp_sym_encrypt(NEW.email::text, current_setting('app.encryption_key'));
+    NEW.ssn := pgp_sym_encrypt(NEW.ssn::text, current_setting('app.encryption_key'));
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_encrypt_user_pii
+BEFORE INSERT OR UPDATE ON users
+FOR EACH ROW EXECUTE FUNCTION encrypt_user_pii();


### PR DESCRIPTION
## Summary
- describe how to use pgcrypto in README
- add migration to enable pgcrypto and encrypt PII columns
- fix placeholder test file so pytest runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872a1655c088320ba1eb89d0ae2a82c