### PR TITLE
Add K8s network policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Kubernetes Network Policies
+
+The `k8s/network-policies.yaml` manifest defines default isolation for the
+`backend` and `ai-matcher-service` namespaces. Each policy restricts ingress and
+egress traffic to pods within the same namespace, preventing unintended
+communication between micro-services in different namespaces.
+
+Apply the policies with:
+
+```bash
+kubectl apply -f k8s/network-policies.yaml
+```
+

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/k8s/network-policies.yaml
+++ b/k8s/network-policies.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backend-isolate
+  namespace: backend
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  egress:
+  - to:
+    - podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ai-matcher-isolate
+  namespace: ai-matcher-service
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  egress:
+  - to:
+    - podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
## Summary
- add default-deny network policies for backend and ai-matcher-service namespaces
- mention policies in README
- fix comment in placeholder Python test so `pytest` succeeds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875a6c4b4b883208521f54a90a8b7d2