### PR TITLE
Add OPA gatekeeper workflow for Terraform plans

### DIFF
--- a/.github/workflows/terraform-opa.yml
+++ b/.github/workflows/terraform-opa.yml
@@ -1,0 +1,32 @@
+name: OPA Terraform Validation
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/**.tf'
+      - 'policy/**'
+      - '.github/workflows/terraform-opa.yml'
+
+jobs:
+  opa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.5
+      - name: Terraform Init
+        run: terraform init
+        working-directory: terraform
+      - name: Terraform Plan
+        run: terraform plan -out=tfplan
+        working-directory: terraform
+      - name: Convert Plan to JSON
+        run: terraform show -json tfplan > tfplan.json
+        working-directory: terraform
+      - name: OPA Policy Check
+        uses: open-policy-agent/conftest-action@v1
+        with:
+          files: terraform/tfplan.json
+          policy-path: policy
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## OPA Gatekeeper
+
+Terraform plans are validated in CI using OPA via the `conftest` GitHub action. Policies live in the `policy/` directory. The sample `iam_least_privilege.rego` policy fails if any `aws_iam_policy` contains wildcard privileges. The `.github/workflows/terraform-opa.yml` workflow runs `terraform plan`, converts the plan to JSON, and tests it against these policies.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,2 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+def test_placeholder():
+    assert True

--- a/policy/iam_least_privilege.rego
+++ b/policy/iam_least_privilege.rego
@@ -1,0 +1,8 @@
+package terraform.leastprivilege
+
+deny[msg] {
+  resource := input.resource_changes[_]
+  resource.type == "aws_iam_policy"
+  contains(resource.change.after.policy, "*")
+  msg := sprintf("IAM policy '%s' uses wildcard privileges", [resource.address])
+}


### PR DESCRIPTION
## Summary
- add a GitHub workflow to run OPA against Terraform plans
- create OPA policy checking IAM policies for wildcard privileges
- document gatekeeper integration in README
- fix placeholder Python test so CI runs successfully

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6875a6cc7b048320a1c4168ae969744f