### PR TITLE
Add self-healing cronjob

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Self-Healing Node CronJob
+
+The file `k8s/self-healing-cronjob.yaml` defines a Kubernetes `CronJob` that
+periodically checks the timestamp of the latest block produced by the node. If
+the age of the last block exceeds five minutes, the CronJob deletes the node
+pod so Kubernetes can restart it. This helps recover from stalled Aura slots.

--- a/k8s/self-healing-cronjob.yaml
+++ b/k8s/self-healing-cronjob.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: self-healer-scripts
+  namespace: default
+data:
+  check_aura_slot.sh: |
+    #!/bin/sh
+    set -eu
+    
+    # RPC endpoint of the Substrate node
+    RPC_ENDPOINT=${RPC_ENDPOINT:-http://substrate-node:9933}
+    # Maximum allowed age of the latest block in seconds
+    AGE_LIMIT=${AGE_LIMIT:-300}
+    # Pod selector used to restart the node
+    POD_SELECTOR=${POD_SELECTOR:-app=substrate-node}
+    
+    # Fetch the latest block and extract the timestamp
+    block_json=$(curl -s -H "Content-Type: application/json" \
+      -d '{"jsonrpc":"2.0","id":1,"method":"chain_getBlock"}' "$RPC_ENDPOINT")
+    
+    block_ts_hex=$(echo "$block_json" | grep -o '"now":"0x[0-9a-f]*"' | head -n1 | sed -E 's/.*"0x([0-9a-f]+)"/\1/')
+    
+    if [ -z "$block_ts_hex" ]; then
+      echo "Could not parse block timestamp"
+      exit 1
+    fi
+    
+    block_ts=$((16#$block_ts_hex / 1000))
+    now=$(date +%s)
+    age=$((now - block_ts))
+    
+    echo "Latest block age: $age seconds"
+    
+    if [ "$age" -gt "$AGE_LIMIT" ]; then
+      echo "Stalled Aura slot detected. Restarting node pods..."
+      kubectl delete pod -l "$POD_SELECTOR"
+    else
+      echo "Node is healthy"
+    fi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: substrate-self-healer
+  namespace: default
+spec:
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: self-healer
+            image: bitnami/kubectl:latest
+            command:
+            - /bin/sh
+            - -c
+            - |
+              /scripts/check_aura_slot.sh
+            volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          volumes:
+          - name: scripts
+            configMap:
+              name: self-healer-scripts
+              defaultMode: 0755


### PR DESCRIPTION
## Summary
- monitor Aura chain slot progress
- restart node pod if the slot stops advancing
- document how the cronjob works

## Testing
- `pytest` *(fails: SyntaxError in placeholder test_matcher.py)*
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6875a70610f08320882cbd51af0b4dd1