### PR TITLE
Enable Istio mTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Istio mTLS
+
+The Kubernetes configuration now includes an `istio-mtls.yaml` manifest. This
+manifest configures a cluster-wide `PeerAuthentication` policy in `STRICT` mode
+and a `DestinationRule` that forces `ISTIO_MUTUAL` TLS for service-to-service
+traffic. Apply this file after deploying the services to ensure mutual TLS is
+enforced between microservices.

--- a/k8s/istio-mtls.yaml
+++ b/k8s/istio-mtls.yaml
@@ -1,0 +1,19 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: default
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: default
+  namespace: default
+spec:
+  host: "*.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL


### PR DESCRIPTION
## Summary
- configure Istio mutual TLS for microservices
- document usage in the README

## Testing
- `pytest -q` *(fails: SyntaxError in ai-matcher-service/tests/test_matcher.py)*

------
https://chatgpt.com/codex/tasks/task_e_6875a71e91b08320b1bbc7c86dbaa2d2