### PR TITLE
Add session re-auth check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Security
+
+Privileged actions now require the user to re-authenticate if their last
+authentication was more than 30 minutes ago. This is enforced in both the
+backend and frontend helpers.

--- a/backend/src/auth/session_reauth.ts
+++ b/backend/src/auth/session_reauth.ts
@@ -1,0 +1,17 @@
+export const MAX_AUTH_AGE_MINUTES = 30;
+
+export interface Session {
+    lastAuthAt: Date | null;
+}
+
+/**
+ * Return true if the session must be re-authenticated before executing a privileged action.
+ */
+export function requiresReauth(session: Session): boolean {
+    if (!session.lastAuthAt) {
+        return true;
+    }
+    const now = Date.now();
+    const elapsed = now - new Date(session.lastAuthAt).getTime();
+    return elapsed > MAX_AUTH_AGE_MINUTES * 60 * 1000;
+}

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,9 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { Session, requiresReauth } from '../auth/session_reauth';
+
+export function issueCredential(session: Session) {
+    if (requiresReauth(session)) {
+        throw new Error('Re-authentication required for privileged action');
+    }
+    // Credential issuing logic placeholder
+    return { status: 'issued' };
+}

--- a/frontend/pages/credentials/[id].tsx
+++ b/frontend/pages/credentials/[id].tsx
@@ -1,1 +1,23 @@
-// [id].tsx - placeholder or stub for chai-vc-platform
+import { useState } from 'react';
+import { needsReauthentication } from '../../utils/session';
+
+export default function CredentialPage() {
+    const [lastAuth, setLastAuth] = useState<Date | null>(null);
+
+    function handlePrivilegedAction() {
+        if (needsReauthentication(lastAuth)) {
+            alert('Please re-authenticate to continue.');
+            setLastAuth(new Date());
+            return;
+        }
+        // perform privileged action (placeholder)
+        console.log('Privileged action executed');
+    }
+
+    return (
+        <div>
+            <h1>Credential</h1>
+            <button onClick={handlePrivilegedAction}>Run privileged action</button>
+        </div>
+    );
+}

--- a/frontend/utils/session.ts
+++ b/frontend/utils/session.ts
@@ -1,0 +1,14 @@
+export const MAX_AUTH_AGE_MINUTES = 30;
+
+/**
+ * Determine if the user should re-authenticate before performing a privileged action.
+ * @param lastAuth timestamp of the user's last authentication
+ */
+export function needsReauthentication(lastAuth: Date | null): boolean {
+    if (!lastAuth) {
+        return true;
+    }
+    const now = Date.now();
+    const elapsed = now - new Date(lastAuth).getTime();
+    return elapsed > MAX_AUTH_AGE_MINUTES * 60 * 1000;
+}


### PR DESCRIPTION
## Summary
- require re-authentication for privileged sessions after 30 minutes
- enforce re-auth in credential controller and example frontend page
- document privileged action re-auth requirement

## Testing
- `npm test` *(fails: command not found)*
- `pytest` *(fails to collect tests)*

------
https://chatgpt.com/codex/tasks/task_e_6875a729c2748320984f41c6056f3a59