### PR TITLE
Implement composite risk score

### DIFF
--- a/ai-matcher-service/src/routes/match.py
+++ b/ai-matcher-service/src/routes/match.py
@@ -1,1 +1,1 @@
-// match.py - placeholder or stub for chai-vc-platform
+"""Placeholder routes for matcher service."""

--- a/ai-matcher-service/src/utils/risk_score.py
+++ b/ai-matcher-service/src/utils/risk_score.py
@@ -1,0 +1,29 @@
+from typing import Tuple
+
+
+def generate_composite_risk_score(npdb_score: float, oig_score: float, state_score: float, weights: Tuple[float, float, float] | None = None) -> float:
+    """Return weighted composite risk score from NPDB, OIG and state checks.
+
+    Each score should be between 0 and 1 inclusive. Optional ``weights`` can
+    be provided as a tuple of three floats that sum to ``1``. The default
+    weighting is ``(0.5, 0.3, 0.2)`` for NPDB, OIG and state respectively.
+    """
+    if weights is None:
+        weights = (0.5, 0.3, 0.2)
+
+    if len(weights) != 3:
+        raise ValueError("weights must contain three values")
+
+    if not abs(sum(weights) - 1.0) < 1e-6:
+        raise ValueError("weights must sum to 1")
+
+    for name, value in {
+        "npdb_score": npdb_score,
+        "oig_score": oig_score,
+        "state_score": state_score,
+    }.items():
+        if not 0 <= value <= 1:
+            raise ValueError(f"{name} must be between 0 and 1")
+
+    w_npdb, w_oig, w_state = weights
+    return npdb_score * w_npdb + oig_score * w_oig + state_score * w_state

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+"""Placeholder tests for matcher service."""

--- a/ai-matcher-service/tests/test_risk_score.py
+++ b/ai-matcher-service/tests/test_risk_score.py
@@ -1,0 +1,25 @@
+import pathlib
+import sys
+import pytest
+
+# Allow importing modules from src/ despite hyphenated package directory
+SRC_PATH = pathlib.Path(__file__).resolve().parents[1] / "src"
+sys.path.append(str(SRC_PATH))
+
+from utils.risk_score import generate_composite_risk_score
+
+
+def test_generate_composite_risk_score_basic():
+    score = generate_composite_risk_score(0.2, 0.3, 0.1)
+    expected = 0.2 * 0.5 + 0.3 * 0.3 + 0.1 * 0.2
+    assert score == pytest.approx(expected)
+
+
+def test_invalid_score_range():
+    with pytest.raises(ValueError):
+        generate_composite_risk_score(1.2, 0, 0)
+
+
+def test_custom_weights():
+    score = generate_composite_risk_score(0.5, 0.5, 0.5, weights=(1, 0, 0))
+    assert score == 0.5


### PR DESCRIPTION
## Summary
- add a utility for calculating a weighted composite risk score
- create tests exercising the risk score logic
- fix placeholder python files so pytest can run

## Testing
- `pytest`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6875a73a8a588320be84f8be2bddbe1f