### PR TITLE
Add DID rotation capability

### DIFF
--- a/backend/__tests__/did_rotation.test.js
+++ b/backend/__tests__/did_rotation.test.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+const { DIDRegistry } = require('../../dist/src/blockchain/did_rotation.js');
+
+const registry = new DIDRegistry();
+const did = { id: 'did:example:123', publicKey: 'oldKey', revokedKeys: [] };
+registry.register(did);
+const updated = registry.rotateKeys('did:example:123', 'newKey');
+assert.strictEqual(updated.publicKey, 'newKey');
+assert.deepStrictEqual(updated.revokedKeys, ['oldKey']);
+console.log('did_rotation test passed');

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,4 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+// Integration layer exposing blockchain capabilities.
+// Currently provides DID key rotation using an in-memory registry.
+
+export { DIDRegistry, DIDDocument } from './did_rotation';

--- a/backend/src/blockchain/did_rotation.ts
+++ b/backend/src/blockchain/did_rotation.ts
@@ -1,0 +1,27 @@
+export interface DIDDocument {
+  id: string;
+  publicKey: string;
+  revokedKeys: string[];
+}
+
+export class DIDRegistry {
+  private registry: Map<string, DIDDocument> = new Map();
+
+  register(doc: DIDDocument): void {
+    this.registry.set(doc.id, { ...doc, revokedKeys: doc.revokedKeys || [] });
+  }
+
+  get(id: string): DIDDocument | undefined {
+    return this.registry.get(id);
+  }
+
+  rotateKeys(id: string, newPublicKey: string): DIDDocument {
+    const doc = this.registry.get(id);
+    if (!doc) {
+      throw new Error(`DID ${id} not found`);
+    }
+    doc.revokedKeys.push(doc.publicKey);
+    doc.publicKey = newPublicKey;
+    return doc;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "rootDir": "./backend/src",
+    "outDir": "./dist/src",
+    "esModuleInterop": true,
+    "strict": true,
+    "moduleResolution": "node"
+  },
+  "include": ["backend/src/**/*.ts"],
+  "exclude": ["**/__tests__"]
+}


### PR DESCRIPTION
## Summary
- introduce `DIDRegistry` with rotation support
- expose the registry from blockchain integration layer
- add a simple JS test for DID rotation
- add basic `tsconfig.json` for compiling backend sources

## Testing
- `npx tsc`
- `node backend/__tests__/did_rotation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6875a74e340c8320b1b3dadf10201307