### PR TITLE
Implement basic i18n structure

### DIFF
--- a/frontend/i18n.ts
+++ b/frontend/i18n.ts
@@ -1,0 +1,11 @@
+import en from './locales/en.json';
+import es from './locales/es.json';
+
+export type Locale = 'en' | 'es';
+
+const translations: Record<Locale, Record<string, string>> = { en, es };
+
+export function t(key: string, locale: Locale = 'en'): string {
+  const langPack = translations[locale] || translations.en;
+  return langPack[key] || translations.en[key] || key;
+}

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "credentialTitle": "Credential Page",
+  "loading": "Loading..."
+}

--- a/frontend/locales/es.json
+++ b/frontend/locales/es.json
@@ -1,0 +1,4 @@
+{
+  "credentialTitle": "Página de Credenciales",
+  "loading": "Cargando..."
+}

--- a/frontend/pages/credentials/[id].tsx
+++ b/frontend/pages/credentials/[id].tsx
@@ -1,1 +1,17 @@
-// [id].tsx - placeholder or stub for chai-vc-platform
+import React from 'react';
+import { t, Locale } from '../../i18n';
+
+interface Props {
+  locale?: Locale;
+}
+
+const CredentialPage: React.FC<Props> = ({ locale = 'en' }) => {
+  return (
+    <div>
+      <h1>{t('credentialTitle', locale)}</h1>
+      <p>{t('loading', locale)}</p>
+    </div>
+  );
+};
+
+export default CredentialPage;


### PR DESCRIPTION
## Summary
- add translation files for English and Spanish
- create a simple i18n helper
- update credential page to use translations

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6875b38a2e548320b1a519ac82d994f2