### PR TITLE
Add PDF dossier download endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/backend/src/dossier.ts
+++ b/backend/src/dossier.ts
@@ -1,0 +1,29 @@
+import PDFDocument from 'pdfkit';
+import crypto from 'crypto';
+
+export interface Credential {
+  id: string;
+  name: string;
+  issued: string;
+}
+
+/**
+ * Generate a PDF dossier for a credential and embed a tamper-evident hash
+ * of the credential JSON data at the end of the document.
+ */
+export function generateCredentialDossier(credential: Credential): PDFKit.PDFDocument {
+  const doc = new PDFDocument();
+  doc.fontSize(20).text('Credential Dossier', { align: 'center' });
+  doc.moveDown();
+
+  doc.fontSize(12).text(`ID: ${credential.id}`);
+  doc.text(`Name: ${credential.name}`);
+  doc.text(`Issued: ${credential.issued}`);
+
+  doc.moveDown();
+  const credentialJson = JSON.stringify(credential);
+  const hash = crypto.createHash('sha256').update(credentialJson).digest('hex');
+  doc.fontSize(10).text(`Credential Hash: ${hash}`);
+
+  return doc;
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,35 @@
+import express from 'express';
+import { generateCredentialDossier } from './dossier';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+// Simple in-memory credential store for demonstration
+interface Credential {
+  id: string;
+  name: string;
+  issued: string;
+}
+
+const credentials: Record<string, Credential> = {
+  '1': { id: '1', name: 'Dr. Alice Smith', issued: '2023-01-01' },
+  '2': { id: '2', name: 'Dr. Bob Jones', issued: '2023-02-15' }
+};
+
+app.get('/credentials/:id/dossier', (req, res) => {
+  const credential = credentials[req.params.id];
+  if (!credential) {
+    res.status(404).send('Credential not found');
+    return;
+  }
+
+  const pdf = generateCredentialDossier(credential);
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', `attachment; filename=credential_${credential.id}.pdf`);
+  pdf.pipe(res);
+  pdf.end();
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "chai-vc-platform",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "backend/src/server.ts",
+  "scripts": {
+    "start": "ts-node backend/src/server.ts",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pdfkit": "^0.13.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.5"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "outDir": "dist"
+  },
+  "include": ["backend/src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add Express server and dossier generator
- compute credential hash for tamper-evident PDF
- configure TypeScript project

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6875b39f87a88320a20c0ed7ff1ed890