### PR TITLE
Add developer portal docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Developer Portal
+
+For API examples and usage instructions, see [docs/DEVELOPER_PORTAL.md](docs/DEVELOPER_PORTAL.md).

--- a/docs/DEVELOPER_PORTAL.md
+++ b/docs/DEVELOPER_PORTAL.md
@@ -1,0 +1,43 @@
+# Chai VC Platform Developer Portal
+
+Welcome to the Chai VC Platform developer portal. This portal provides the basics for interacting with our APIs and testing your integration.
+
+## Getting an API Key
+
+To get started, request an API key from your Chai VC Platform administrator. For testing purposes, you can use the example key below:
+
+```
+example_key_1234567890
+```
+
+Pass your API key using the `X-API-Key` HTTP header with each request.
+
+## Example GraphQL Query
+
+Below is a sample GraphQL query using `curl`. Replace `example_key_1234567890` with your own key when you receive one.
+
+```bash
+curl -X POST https://api.chai-vc.example.com/graphql \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: example_key_1234567890" \
+  -d '{"query": "{ credentials { id status } }"}'
+```
+
+This request queries for a list of credentials. A successful response will look something like this:
+
+```json
+{
+  "data": {
+    "credentials": [
+      {
+        "id": "cred-123",
+        "status": "verified"
+      }
+    ]
+  }
+}
+```
+
+## Further Reading
+
+See the project [README](../README.md) for setup instructions. Additional endpoints and features will appear here as the platform evolves.

--- a/frontend/pages/developer/index.tsx
+++ b/frontend/pages/developer/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const DeveloperPortal: React.FC = () => {
+  return (
+    <div style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>Chai VC Platform Developer Portal</h1>
+      <p>Welcome to the Chai VC Platform developer portal. This page provides basic examples for integrating with our APIs.</p>
+
+      <h2>Example API Key</h2>
+      <pre>example_key_1234567890</pre>
+      <p>Include your API key in the <code>X-API-Key</code> header when making requests.</p>
+
+      <h2>Sample GraphQL Request</h2>
+      <pre>
+curl -X POST https://api.chai-vc.example.com/graphql \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: example_key_1234567890" \
+  -d '{"query": "{ credentials { id status } }"}'
+      </pre>
+    </div>
+  );
+};
+
+export default DeveloperPortal;


### PR DESCRIPTION
## Summary
- add developer portal page under `frontend/pages/developer`
- document API usage in `docs/DEVELOPER_PORTAL.md`
- link to the new portal from `README.md`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68762d05d6cc8320b86a1d7762514347