### PR TITLE
Add PQ cert TODO and fix placeholder test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,3 @@
+# Project Tasks
+
+- [ ] Obtain NIST-approved post-quantum certificate once the standards are finalized.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,4 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform
+
+def test_placeholder():
+    assert True


### PR DESCRIPTION
## Summary
- track requirement to obtain NIST post-quantum certificate once standards are final
- fix placeholder matcher test so CI can run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68762d1bf2b48320be3d4983656063c1