### PR TITLE
Add basic Helm charts and Kustomize overlays

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,20 @@
+# Kubernetes Manifests
+
+This directory provides Helm charts and Kustomize overlays for deploying
+`chai-vc-platform` services.
+
+- `charts/` contains minimal Helm charts for the backend and the
+  `ai-matcher-service`.
+- `base/` is a Kustomize base that renders these charts using the default
+  values.
+- `overlays/` provides environment-specific configuration for `dev`,
+  `staging`, and `prod` environments. Each overlay overrides image tags
+  and replica counts via `valuesInline`.
+
+To render manifests for a given environment you can run:
+
+```bash
+kustomize build k8s/overlays/<env>
+```
+
+Replace `<env>` with `dev`, `staging`, or `prod`.

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmCharts:
+  - name: backend
+    path: ../charts/backend
+    releaseName: backend
+    version: 0.1.0
+  - name: ai-matcher-service
+    path: ../charts/ai-matcher-service
+    releaseName: ai-matcher-service
+    version: 0.1.0

--- a/k8s/charts/ai-matcher-service/Chart.yaml
+++ b/k8s/charts/ai-matcher-service/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: ai-matcher-service
+version: 0.1.0
+appVersion: "1.0"

--- a/k8s/charts/ai-matcher-service/templates/deployment.yaml
+++ b/k8s/charts/ai-matcher-service/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Release.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}

--- a/k8s/charts/ai-matcher-service/templates/service.yaml
+++ b/k8s/charts/ai-matcher-service/templates/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}

--- a/k8s/charts/ai-matcher-service/values.yaml
+++ b/k8s/charts/ai-matcher-service/values.yaml
@@ -1,0 +1,7 @@
+replicaCount: 1
+image:
+  repository: ai-matcher
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  port: 5000

--- a/k8s/charts/backend/Chart.yaml
+++ b/k8s/charts/backend/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: backend
+version: 0.1.0
+appVersion: "1.0"

--- a/k8s/charts/backend/templates/deployment.yaml
+++ b/k8s/charts/backend/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Release.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}

--- a/k8s/charts/backend/templates/service.yaml
+++ b/k8s/charts/backend/templates/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}

--- a/k8s/charts/backend/values.yaml
+++ b/k8s/charts/backend/values.yaml
@@ -1,0 +1,7 @@
+replicaCount: 1
+image:
+  repository: backend
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  port: 80

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+helmCharts:
+  - name: backend
+    path: ../../charts/backend
+    releaseName: backend
+    version: 0.1.0
+    valuesInline:
+      image:
+        tag: dev
+      replicaCount: 1
+  - name: ai-matcher-service
+    path: ../../charts/ai-matcher-service
+    releaseName: ai-matcher-service
+    version: 0.1.0
+    valuesInline:
+      image:
+        tag: dev
+      replicaCount: 1

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+helmCharts:
+  - name: backend
+    path: ../../charts/backend
+    releaseName: backend
+    version: 0.1.0
+    valuesInline:
+      image:
+        tag: prod
+      replicaCount: 3
+  - name: ai-matcher-service
+    path: ../../charts/ai-matcher-service
+    releaseName: ai-matcher-service
+    version: 0.1.0
+    valuesInline:
+      image:
+        tag: prod
+      replicaCount: 3

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+helmCharts:
+  - name: backend
+    path: ../../charts/backend
+    releaseName: backend
+    version: 0.1.0
+    valuesInline:
+      image:
+        tag: staging
+      replicaCount: 2
+  - name: ai-matcher-service
+    path: ../../charts/ai-matcher-service
+    releaseName: ai-matcher-service
+    version: 0.1.0
+    valuesInline:
+      image:
+        tag: staging
+      replicaCount: 2


### PR DESCRIPTION
## Summary
- add minimal Helm charts for backend and ai matcher
- add a base kustomization and overlays for dev, staging, and prod
- document how to use Kustomize with these Helm charts

## Testing
- `apt-get update`
- `apt-get install -y kustomize` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687640b373e08320b809ae97b9710ac5