### PR TITLE
Add Loki stack with alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Logging and Monitoring
+
+The `k8s/logging` directory contains a sample Loki stack deployment. It runs Loki,
+Promtail and Grafana inside a `logging` namespace. Grafana is preconfigured with
+a Loki data source and an alert rule that triggers if more than 2% of backend
+logs contain the word `error` over a five minute window. Apply the manifest with:
+
+```bash
+kubectl apply -f k8s/logging/loki-stack.yaml
+```
+
+Grafana is exposed via a `NodePort` on port `3000`. Sign in (default credentials
+`admin`/`admin`) and navigate to **Alerting** to view the rule.

--- a/k8s/logging/loki-stack.yaml
+++ b/k8s/logging/loki-stack.yaml
@@ -1,0 +1,249 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  namespace: logging
+spec:
+  serviceName: loki
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+      - name: loki
+        image: grafana/loki:2.8.0
+        args:
+        - -config.file=/etc/loki/loki.yaml
+        ports:
+        - containerPort: 3100
+        volumeMounts:
+        - name: config
+          mountPath: /etc/loki
+        - name: data
+          mountPath: /var/loki
+      volumes:
+      - name: config
+        configMap:
+          name: loki-config
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: logging
+data:
+  loki.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+    ingester:
+      lifecycler:
+        ring:
+          kvstore:
+            store: inmemory
+          replication_factor: 1
+      chunk_idle_period: 5m
+    schema_config:
+      configs:
+      - from: 2024-01-01
+        store: boltdb-shipper
+        object_store: filesystem
+        schema: v11
+        index:
+          prefix: loki_index_
+          period: 168h
+    storage_config:
+      boltdb_shipper:
+        active_index_directory: /var/loki/index
+        cache_location: /var/loki/cache
+        shared_store: filesystem
+      filesystem:
+        directory: /var/loki/chunks
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: logging
+spec:
+  ports:
+  - port: 3100
+    name: http
+  selector:
+    app: loki
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: logging
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      serviceAccountName: promtail
+      containers:
+      - name: promtail
+        image: grafana/promtail:2.8.0
+        args:
+        - -config.file=/etc/promtail/promtail.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /etc/promtail
+        - name: varlog
+          mountPath: /var/log
+        - name: containers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: promtail-config
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: containers
+        hostPath:
+          path: /var/lib/docker/containers
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: logging
+data:
+  promtail.yaml: |
+    serverPort: 9080
+    positions:
+      filename: /tmp/positions.yaml
+    clients:
+      - url: http://loki.logging.svc.cluster.local:3100/loki/api/v1/push
+    scrape_configs:
+      - job_name: system
+        static_configs:
+          - targets:
+              - localhost
+            labels:
+              job: varlogs
+              __path__: /var/log/*log
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana:10.0.0
+        ports:
+        - containerPort: 3000
+        volumeMounts:
+        - name: datasource
+          mountPath: /etc/grafana/provisioning/datasources
+        - name: alerting
+          mountPath: /etc/grafana/provisioning/alerting
+      volumes:
+      - name: datasource
+        configMap:
+          name: grafana-datasource
+      - name: alerting
+        configMap:
+          name: grafana-alert
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource
+  namespace: logging
+data:
+  datasource.yaml: |
+    apiVersion: 1
+    datasources:
+    - name: Loki
+      type: loki
+      access: proxy
+      url: http://loki.logging.svc.cluster.local:3100
+      isDefault: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-alert
+  namespace: logging
+data:
+  alerting.yaml: |
+    apiVersion: 1
+    groups:
+    - name: ErrorRateRule
+      interval: 1m
+      rules:
+      - uid: error-rate-high
+        title: High error rate
+        condition: B
+        data:
+        - refId: A
+          datasourceUid: Loki
+          relativeTimeRange:
+            from: 300
+            to: 0
+          queryType: range
+          expr: sum(rate({app="backend"} |= "error" [5m])) / sum(rate({app="backend"}[5m])) * 100
+        - refId: B
+          datasourceUid: Loki
+          relativeTimeRange:
+            from: 300
+            to: 0
+          queryType: expression
+          expression: A > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Error rate is above 2%
+          description: More than 2% of logs from backend contain errors
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: logging
+spec:
+  type: NodePort
+  ports:
+  - port: 3000
+    targetPort: 3000
+  selector:
+    app: grafana


### PR DESCRIPTION
## Summary
- add Kubernetes manifest `loki-stack.yaml` to deploy Loki, Promtail and Grafana
- configure Grafana alert for backend log error rate >2%
- document how to apply the stack in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687640c387f08320aa3e1ebc7cd4f45f