### PR TITLE
Archive pipeline artifacts to Glacier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+See [docs/retention.md](docs/retention.md) for details on pipeline artifact retention and archiving to S3 Glacier.

--- a/docs/retention.md
+++ b/docs/retention.md
@@ -1,0 +1,11 @@
+# Pipeline Artifact Retention
+
+Pipeline build artifacts are stored in an S3 bucket. Artifacts older than 30 days are automatically archived to Amazon S3 Glacier for cost-effective long term storage.
+
+To apply the lifecycle policy manually or to a new bucket, run:
+
+```bash
+./scripts/archive_old_pipeline_artifacts.sh <bucket-name>
+```
+
+This command configures the bucket to transition artifacts to Glacier after 30 days.

--- a/scripts/archive_old_pipeline_artifacts.sh
+++ b/scripts/archive_old_pipeline_artifacts.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Script to configure S3 lifecycle policy to archive pipeline artifacts older than 30 days to Glacier
+# Usage: ./archive_old_pipeline_artifacts.sh <bucket-name>
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <bucket-name>" >&2
+  exit 1
+fi
+
+BUCKET="$1"
+
+echo "Configuring lifecycle policy for bucket $BUCKET..."
+aws s3api put-bucket-lifecycle-configuration --bucket "$BUCKET" --lifecycle-configuration '{
+  "Rules": [
+    {
+      "ID": "ArchivePipelineArtifacts",
+      "Filter": {"Prefix": ""},
+      "Status": "Enabled",
+      "Transitions": [
+        {"Days": 30, "StorageClass": "GLACIER"}
+      ]
+    }
+  ]
+}'
+
+echo "Lifecycle policy applied."


### PR DESCRIPTION
## Summary
- keep artifacts longer-term by transitioning to S3 Glacier after 30 days
- document artifact retention policy
- reference the retention documentation from the main README

## Testing
- `no tests`


------
https://chatgpt.com/codex/tasks/task_e_687641167ef083208038e100c12cfd1c