### PR TITLE
Enable nightly GraphQL docs

### DIFF
--- a/.github/workflows/graphql-docs.yml
+++ b/.github/workflows/graphql-docs.yml
@@ -1,0 +1,27 @@
+name: Generate GraphQL Docs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Generate schema docs
+        env:
+          GRAPHQL_ENDPOINT: ${{ secrets.GRAPHQL_ENDPOINT }}
+        run: |
+          python scripts/generate_graphql_docs.py
+      - name: Commit docs
+        run: |
+          git config user.email "github-actions@github.com"
+          git config user.name "github-actions"
+          git add developer-portal/schema.json developer-portal/schema.md
+          git commit -m "Update GraphQL schema docs" || echo "No changes"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Developer Portal Docs
+
+GraphQL schema documentation is generated nightly via a scheduled GitHub Action. The generated files can be found under `developer-portal/` and are automatically kept up to date.

--- a/scripts/generate_graphql_docs.py
+++ b/scripts/generate_graphql_docs.py
@@ -1,0 +1,65 @@
+import json
+import os
+import urllib.request
+
+# Endpoint for GraphQL server
+endpoint = os.environ.get("GRAPHQL_ENDPOINT", "http://localhost:4000/graphql")
+
+INTROSPECTION_QUERY = """
+query IntrospectionQuery {
+  __schema {
+    types {
+      kind
+      name
+      description
+      fields {
+        name
+        description
+      }
+    }
+  }
+}
+"""
+
+def fetch_schema(url: str) -> dict:
+    data = json.dumps({"query": INTROSPECTION_QUERY}).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req) as response:
+        result = json.load(response)
+    return result.get("data", {}).get("__schema", {})
+
+def write_json(schema: dict, path: str) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(schema, fh, indent=2)
+
+def write_markdown(schema: dict, path: str) -> None:
+    lines = ["# GraphQL Schema", ""]
+    for t in schema.get("types", []):
+        fields = t.get("fields")
+        if not fields:
+            continue
+        lines.append(f"## {t['name']} ({t['kind']})")
+        if t.get("description"):
+            lines.append(t["description"])
+        for f in fields:
+            desc = f.get("description", "")
+            if desc:
+                lines.append(f"- **{f['name']}**: {desc}")
+            else:
+                lines.append(f"- **{f['name']}**")
+        lines.append("")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines))
+
+def main() -> None:
+    try:
+        schema = fetch_schema(endpoint)
+    except Exception as e:
+        raise SystemExit(f"Failed to fetch schema: {e}")
+
+    os.makedirs("developer-portal", exist_ok=True)
+    write_json(schema, "developer-portal/schema.json")
+    write_markdown(schema, "developer-portal/schema.md")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document developer portal docs in README
- add script to fetch schema and write docs
- create GitHub Action to update docs nightly

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68764138ef208320a69be6675f3f035b