### PR TITLE
Add Sentinel policy to prevent public S3 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Sentinel Policies
+
+This repository includes Sentinel policies used with Terraform Cloud. The policy `forbid-public-s3-buckets` ensures that S3 buckets cannot be created with public ACLs (`public-read` or `public-read-write`).
+

--- a/sentinel/forbid_public_s3_buckets.sentinel
+++ b/sentinel/forbid_public_s3_buckets.sentinel
@@ -1,0 +1,12 @@
+import "tfplan/v2" as tfplan
+
+public_buckets = filter tfplan.resource_changes as rc {
+    rc.type is "aws_s3_bucket" and (
+        rc.change.after.acl is "public-read" or
+        rc.change.after.acl is "public-read-write"
+    )
+}
+
+main = rule {
+    length(public_buckets) is 0
+}

--- a/sentinel/sentinel.hcl
+++ b/sentinel/sentinel.hcl
@@ -1,0 +1,3 @@
+policy "forbid-public-s3-buckets" {
+  source = "forbid_public_s3_buckets.sentinel"
+}


### PR DESCRIPTION
## Summary
- add a Sentinel policy that prevents creation of S3 buckets with public ACLs
- register the policy in `sentinel.hcl`
- document Sentinel policies in README

## Testing
- `pytest -q` *(fails: SyntaxError in test placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_687641001c688320a27bb049075fe0e0