### PR TITLE
Add prototype zero-knowledge license proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Zero-Knowledge Proof Prototype
+
+The `zkp/prototype_license_zkp.py` script demonstrates a simple private query
+zero-knowledge proof. It uses the Schnorr identification protocol so a prover
+can convince a verifier that they hold a valid license secret without revealing
+any license details. Run it with:
+
+```bash
+python3 zkp/prototype_license_zkp.py
+```
+
+The script is purely illustrative and **not** production ready.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,4 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform
+
+def test_placeholder():
+    assert True

--- a/zkp/prototype_license_zkp.py
+++ b/zkp/prototype_license_zkp.py
@@ -1,0 +1,59 @@
+"""Prototype zero-knowledge proof for private license query.
+
+This script demonstrates a very basic Schnorr identification proof where a prover
+can prove knowledge of a secret (e.g. a license key) without revealing it. The
+verifier only learns whether the prover actually knows the secret corresponding
+to a public value.
+
+This is **for demonstration only** and should not be used in production.
+"""
+
+import secrets
+
+class SchnorrZKP:
+    def __init__(self, p: int, g: int):
+        self.p = p
+        self.g = g
+        self.q = p - 1  # group order (not secure, for demo only)
+
+    def generate_keys(self):
+        """Generate a secret/public key pair."""
+        secret = secrets.randbelow(self.q)
+        public = pow(self.g, secret, self.p)
+        return secret, public
+
+    def prove(self, secret: int, challenge: int):
+        """Prover computes a response for the given challenge."""
+        k = secrets.randbelow(self.q)
+        t = pow(self.g, k, self.p)
+        s = (k + challenge * secret) % self.q
+        return t, s
+
+    def verify(self, public: int, t: int, challenge: int, s: int) -> bool:
+        left = pow(self.g, s, self.p)
+        right = (t * pow(public, challenge, self.p)) % self.p
+        return left == right
+
+def demo():
+    # Large prime for the group; small here for readability
+    p = 208351617316091241234326746312124448251235562226470491514186331217050270460481
+    g = 2
+    scheme = SchnorrZKP(p, g)
+
+    # Prover's secret (license key) and corresponding public value
+    secret, public = scheme.generate_keys()
+
+    # Verifier knows the public value and issues a random challenge
+    challenge = secrets.randbelow(scheme.q)
+
+    # Prover generates proof
+    t, s = scheme.prove(secret, challenge)
+
+    # Verifier checks the proof
+    if scheme.verify(public, t, challenge, s):
+        print("Proof verified: prover has the license")
+    else:
+        print("Proof failed: invalid license or wrong secret")
+
+if __name__ == "__main__":
+    demo()


### PR DESCRIPTION
## Summary
- add a Python script that demonstrates a simple Schnorr identification protocol for a license query
- include a placeholder test
- document how to run the prototype in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687641ded44c8320bb30830eda0de14e