### PR TITLE
Add partner portal theming system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+frontend/dist
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Partner Portal Templates
+
+The `frontend` folder includes a simple theming system for building white-labeled partner portals.
+
+### Building a Theme
+
+Run the build script from the `frontend` directory with the desired theme name. The generated HTML and CSS will be written to `frontend/dist`.
+
+```bash
+cd frontend
+python build.py [theme-name]
+```
+
+For example, to build the sample partner theme:
+
+```bash
+python build.py partner_sample
+```
+
+Customize the files under `frontend/themes/<your-theme>` to create a branded portal.

--- a/frontend/build.py
+++ b/frontend/build.py
@@ -1,0 +1,33 @@
+import sys
+import pathlib
+import shutil
+
+BASE_TEMPLATE = pathlib.Path('templates') / 'base.html'
+THEMES_DIR = pathlib.Path('themes')
+
+def build(theme_name: str, out_dir: str = 'dist') -> None:
+    theme_dir = THEMES_DIR / theme_name
+    if not theme_dir.exists():
+        raise FileNotFoundError(f"Theme '{theme_name}' not found")
+
+    out_path = pathlib.Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    template = BASE_TEMPLATE.read_text()
+    header = (theme_dir / 'header.html').read_text()
+    footer = (theme_dir / 'footer.html').read_text()
+    css_src = theme_dir / 'theme.css'
+    css_dst = out_path / 'theme.css'
+    shutil.copyfile(css_src, css_dst)
+
+    html = template.replace('{{title}}', 'Partner Portal') \
+                   .replace('{{header}}', header) \
+                   .replace('{{footer}}', footer) \
+                   .replace('{{theme_css}}', 'theme.css')
+
+    (out_path / 'index.html').write_text(html)
+    print(f"Generated {out_path / 'index.html'}")
+
+if __name__ == '__main__':
+    theme = sys.argv[1] if len(sys.argv) > 1 else 'default'
+    build(theme)

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{title}}</title>
+  <link rel="stylesheet" href="{{theme_css}}">
+</head>
+<body>
+  {{header}}
+  <main>
+    <h1>Welcome to the partner portal</h1>
+    <p>This template can be white-labeled by customizing the theme.</p>
+  </main>
+  {{footer}}
+</body>
+</html>

--- a/frontend/themes/default/footer.html
+++ b/frontend/themes/default/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p>© Chai VC</p>
+</footer>

--- a/frontend/themes/default/header.html
+++ b/frontend/themes/default/header.html
@@ -1,0 +1,3 @@
+<header>
+  <h1>Chai VC</h1>
+</header>

--- a/frontend/themes/default/theme.css
+++ b/frontend/themes/default/theme.css
@@ -1,0 +1,14 @@
+:root {
+  --primary-color: #0044cc;
+  --background-color: #ffffff;
+}
+body {
+  background: var(--background-color);
+  color: #333;
+  font-family: Arial, sans-serif;
+}
+header, footer {
+  background: var(--primary-color);
+  color: #fff;
+  padding: 1rem;
+}

--- a/frontend/themes/partner_sample/footer.html
+++ b/frontend/themes/partner_sample/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p>© Partner Sample</p>
+</footer>

--- a/frontend/themes/partner_sample/header.html
+++ b/frontend/themes/partner_sample/header.html
@@ -1,0 +1,3 @@
+<header>
+  <h1>Partner Sample</h1>
+</header>

--- a/frontend/themes/partner_sample/theme.css
+++ b/frontend/themes/partner_sample/theme.css
@@ -1,0 +1,14 @@
+:root {
+  --primary-color: #008000;
+  --background-color: #f2fff2;
+}
+body {
+  background: var(--background-color);
+  color: #333;
+  font-family: Arial, sans-serif;
+}
+header, footer {
+  background: var(--primary-color);
+  color: #fff;
+  padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- add basic theming system for partner portals
- include default and sample themes
- provide build script to generate white‑labeled templates
- document usage in README

## Testing
- `pytest -q` *(fails: SyntaxError in test placeholder)*
- `python frontend/build.py partner_sample`

------
https://chatgpt.com/codex/tasks/task_e_68806b35acf883209cf89e08e0151f38