### PR TITLE
Add CHAI verification browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Browser Extension
+See the [browser-extension](browser-extension/README.md) folder for a simple extension that surfaces CHAI verification status on LinkedIn profiles.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -1,0 +1,10 @@
+# CHAI Verification Browser Extension
+
+This simple browser extension displays CHAI credential verification on LinkedIn profiles.
+
+## Setup
+1. Open your browser's extension settings and enable developer mode.
+2. Load the `browser-extension` folder as an unpacked extension.
+3. Visit a LinkedIn profile to see the CHAI verification status.
+
+The script queries `https://chai.example.com/verify?profile=<name>` to retrieve verification information. Update the endpoint in `content.js` if your API differs.

--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -1,0 +1,45 @@
+// content.js - Injects CHAI verification status into LinkedIn profiles
+
+async function fetchVerificationStatus(profileName) {
+  try {
+    const response = await fetch(`https://chai.example.com/verify?profile=${encodeURIComponent(profileName)}`);
+    if (!response.ok) throw new Error('Request failed');
+    const data = await response.json();
+    return data.verified;
+  } catch (err) {
+    console.error('Verification check failed:', err);
+    return null;
+  }
+}
+
+function insertStatus(status) {
+  const container = document.createElement('div');
+  container.style.fontWeight = 'bold';
+  container.style.marginTop = '8px';
+  if (status === true) {
+    container.textContent = 'CHAI Verified';
+    container.style.color = 'green';
+  } else if (status === false) {
+    container.textContent = 'Not CHAI Verified';
+    container.style.color = 'red';
+  } else {
+    container.textContent = 'CHAI verification unavailable';
+    container.style.color = 'gray';
+  }
+  const anchor = document.querySelector('.pv-top-card');
+  if (anchor) {
+    anchor.appendChild(container);
+  }
+}
+
+function getProfileName() {
+  const element = document.querySelector('h1');
+  return element ? element.textContent.trim() : null;
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const profileName = getProfileName();
+  if (!profileName) return;
+  const status = await fetchVerificationStatus(profileName);
+  insertStatus(status);
+});

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "CHAI Verification",
+  "description": "Displays CHAI verification status on LinkedIn profiles.",
+  "version": "1.0",
+  "permissions": [
+    "activeTab",
+    "scripting"
+  ],
+  "host_permissions": [
+    "https://www.linkedin.com/*",
+    "https://chai.example.com/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["https://www.linkedin.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add simple browser extension to show CHAI verification on LinkedIn
- fix placeholder test comment
- document the new extension in README

## Testing
- `pytest`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68806ae9aa708320bb190da30c980cc7