### PR TITLE
Add GDPR data portability export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## GDPR Data Portability Export
+
+A helper script is included to export a user's Verifiable Credentials in a
+zip file. Credentials are expected to be stored as JSON-LD files under
+`data/vcs/<user_id>/`.
+
+Run the exporter with Python:
+
+```bash
+python backend/src/data_portability/export_vcs.py <user_id>
+```
+
+The archive will be written to the `exports/` directory as
+`<user_id>_vcs.zip`.

--- a/backend/__tests__/test_export_vcs.py
+++ b/backend/__tests__/test_export_vcs.py
@@ -1,0 +1,32 @@
+import os
+import json
+import zipfile
+import tempfile
+import unittest
+
+from backend.src.data_portability.export_vcs import export_credentials_to_zip
+
+
+class ExportVcsTest(unittest.TestCase):
+    def test_export_creates_zip_with_credentials(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            user_id = "user123"
+            user_dir = os.path.join(tmp, user_id)
+            os.makedirs(user_dir, exist_ok=True)
+            with open(os.path.join(user_dir, "cred1.jsonld"), "w") as f:
+                json.dump({"@context": "https://www.w3.org/2018/credentials/v1"}, f)
+            with open(os.path.join(user_dir, "cred2.json"), "w") as f:
+                json.dump({"@context": "https://www.w3.org/2018/credentials/v1"}, f)
+
+            output_dir = os.path.join(tmp, "out")
+            zip_path = export_credentials_to_zip(user_id, tmp, output_dir)
+
+            self.assertTrue(os.path.exists(zip_path))
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                names = zf.namelist()
+                self.assertIn("cred1.jsonld", names)
+                self.assertIn("cred2.json", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/src/data_portability/export_vcs.py
+++ b/backend/src/data_portability/export_vcs.py
@@ -1,0 +1,60 @@
+import os
+import zipfile
+from typing import Optional
+
+
+def export_credentials_to_zip(user_id: str, credentials_dir: str = "data/vcs", output_dir: str = "exports") -> str:
+    """Export a user's JSON-LD credentials as a zip archive.
+
+    Parameters
+    ----------
+    user_id: str
+        Identifier for the user whose credentials will be exported.
+    credentials_dir: str
+        Base directory containing user credential folders.
+    output_dir: str
+        Directory where the zip archive will be created.
+
+    Returns
+    -------
+    str
+        Path to the created zip archive.
+    """
+    user_dir = os.path.join(credentials_dir, user_id)
+    if not os.path.isdir(user_dir):
+        raise FileNotFoundError(f"Credentials directory '{user_dir}' not found.")
+
+    os.makedirs(output_dir, exist_ok=True)
+    zip_path = os.path.join(output_dir, f"{user_id}_vcs.zip")
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for root, _, files in os.walk(user_dir):
+            for fname in files:
+                if fname.lower().endswith((".json", ".jsonld")):
+                    file_path = os.path.join(root, fname)
+                    arcname = os.path.relpath(file_path, user_dir)
+                    zf.write(file_path, arcname)
+    return zip_path
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Export user VCs as a zip of JSON-LD files (GDPR data portability)."
+    )
+    parser.add_argument("user_id", help="User identifier")
+    parser.add_argument(
+        "--credentials-dir",
+        default="data/vcs",
+        help="Base directory where user credential folders are stored",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="exports",
+        help="Directory to write the resulting zip archive",
+    )
+
+    args = parser.parse_args()
+    path = export_credentials_to_zip(args.user_id, args.credentials_dir, args.output_dir)
+    print(f"Exported credentials to {path}")


### PR DESCRIPTION
## Summary
- implement `export_credentials_to_zip` utility for GDPR data portability
- document the export script in README
- test exporting credentials

## Testing
- `python -m unittest discover backend/__tests__`

------
https://chatgpt.com/codex/tasks/task_e_687641f659d083209acf036a11ef58be