### PR TITLE
Add emergency scheduler stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+This repository contains placeholder code for various services. A small
+on-chain scheduler stub has been added under `backend/src/blockchain` to
+demonstrate how an emergency node redeploy could be scheduled via the
+Substrate `pallet-scheduler`.

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,5 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+// blockchain_integration.ts - skeleton blockchain integration
+// Exposes functions used across the backend when interacting with a
+// Substrate-based chain.
+
+export { scheduleEmergencyRedeploy } from './emergency_scheduler';

--- a/backend/src/blockchain/emergency_scheduler.ts
+++ b/backend/src/blockchain/emergency_scheduler.ts
@@ -1,0 +1,15 @@
+export interface ScheduleOptions {
+  atBlock: number;
+  call: any; // placeholder for call to be executed
+}
+
+// scheduleEmergencyRedeploy - schedules an emergency node redeploy
+// using the on-chain scheduler pallet. This is a stub showing how it
+// could interact with polkadot.js API.
+export async function scheduleEmergencyRedeploy(api: any, opts: ScheduleOptions): Promise<void> {
+  // In a real implementation, the call would be encoded using the
+  // chain's metadata and submitted to the scheduler pallet.
+  // Example:
+  // await api.tx.scheduler.schedule(opts.atBlock, null, 0, opts.call).signAndSend();
+  console.log('Scheduling emergency redeploy at block', opts.atBlock);
+}


### PR DESCRIPTION
## Summary
- add a TypeScript stub for scheduling emergency node redeploys via Substrate's on-chain scheduler pallet
- expose `scheduleEmergencyRedeploy` from blockchain integration
- update README to mention the new scheduler stub

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764204d8008320a7d347a40e6a3a4c