### PR TITLE
Add step order RL optimizer

### DIFF
--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/engine/step_order_rl.py
+++ b/engine/step_order_rl.py
@@ -1,0 +1,59 @@
+import itertools
+import random
+from typing import Callable, List, Tuple
+
+class Step:
+    """Represents a single step in the engine."""
+    def __init__(self, name: str, duration: float, fn: Callable[[], None] = None):
+        self.name = name
+        self.duration = duration
+        self.fn = fn if fn is not None else (lambda: None)
+
+    def run(self) -> float:
+        """Execute the step and return its duration."""
+        self.fn()
+        return self.duration
+
+class StepOrderOptimizer:
+    """Simple reinforcement learning optimizer that searches for the order of
+    steps with the best throughput."""
+
+    def __init__(self, steps: List[Step]):
+        self.steps = steps
+        self.orders = list(itertools.permutations(range(len(steps))))
+        self.q_values = {o: 0.0 for o in self.orders}
+        self.counts = {o: 0 for o in self.orders}
+
+    def _throughput(self, order: Tuple[int, ...]) -> float:
+        total_time = sum(self.steps[i].duration for i in order)
+        return len(order) / total_time
+
+    def _choose_order(self, epsilon: float) -> Tuple[int, ...]:
+        if random.random() < epsilon or all(c == 0 for c in self.counts.values()):
+            return random.choice(self.orders)
+        return max(self.orders, key=lambda o: self.q_values[o])
+
+    def train(self, episodes: int = 1000, epsilon: float = 0.1) -> None:
+        for _ in range(episodes):
+            order = self._choose_order(epsilon)
+            reward = self._throughput(order)
+            self.counts[order] += 1
+            c = self.counts[order]
+            # running average update
+            self.q_values[order] += (reward - self.q_values[order]) / c
+
+    def best_order(self) -> List[Step]:
+        best = max(self.orders, key=lambda o: self.q_values[o])
+        return [self.steps[i] for i in best]
+
+if __name__ == "__main__":
+    # demo usage
+    steps = [
+        Step("fetch", 0.3),
+        Step("process", 0.1),
+        Step("store", 0.2),
+    ]
+    opt = StepOrderOptimizer(steps)
+    opt.train(episodes=5000)
+    order = opt.best_order()
+    print("Optimized order:", [s.name for s in order])

--- a/engine/tests/test_step_order_rl.py
+++ b/engine/tests/test_step_order_rl.py
@@ -1,0 +1,17 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+from engine.step_order_rl import Step, StepOrderOptimizer
+
+
+def test_optimizer_returns_order():
+    steps = [
+        Step("a", 0.3),
+        Step("b", 0.1),
+        Step("c", 0.2),
+    ]
+    opt = StepOrderOptimizer(steps)
+    opt.train(episodes=100)
+    order = opt.best_order()
+    assert len(order) == len(steps)
+    assert set(s.name for s in order) == {"a", "b", "c"}
+


### PR DESCRIPTION
## Summary
- add `step_order_rl` module implementing a simple RL loop for step order optimization
- add unit test verifying the optimizer returns valid step order
- make existing test file syntactically valid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876438238c48320b1d1f203935bf121