### PR TITLE
Implement on-chain AI decision anchoring

### DIFF
--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,21 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { PolkadotService } from './polkadot_service';
+import { hashAndStoreDecision } from './decisions_pallet';
+
+const polkadotService = new PolkadotService();
+
+/**
+ * Anchor a piece of AI-generated output on-chain by hashing it and sending
+ * it to the `decisions` pallet.
+ *
+ * @param endpoint - WebSocket endpoint of the target chain.
+ * @param aiOutput - Raw AI output that should be anchored on-chain.
+ * @param signer - Account used to sign the transaction.
+ */
+export async function anchorDecision(
+  endpoint: string,
+  aiOutput: string,
+  signer: any
+): Promise<string> {
+  const api = await polkadotService.connect(endpoint);
+  return hashAndStoreDecision(api, aiOutput, signer);
+}

--- a/backend/src/blockchain/decisions_pallet.ts
+++ b/backend/src/blockchain/decisions_pallet.ts
@@ -1,0 +1,25 @@
+import { ApiPromise } from '@polkadot/api';
+import { blake2AsHex, cryptoWaitReady } from '@polkadot/util-crypto';
+
+/**
+ * Hash AI output using Blake2 and store it on-chain via the `decisions` pallet.
+ *
+ * @param api - Initialized Polkadot API instance.
+ * @param aiOutput - Raw output from the AI system.
+ * @param signer - Account that will submit the transaction.
+ * @returns The hex-encoded hash that was stored on-chain.
+ */
+export async function hashAndStoreDecision(
+  api: ApiPromise,
+  aiOutput: string,
+  signer: any
+): Promise<string> {
+  await cryptoWaitReady();
+  const decisionHash = blake2AsHex(aiOutput);
+
+  await api.tx.decisions
+    .recordDecision(decisionHash)
+    .signAndSend(signer);
+
+  return decisionHash;
+}

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,14 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
+export class PolkadotService {
+  private api?: ApiPromise;
+
+  async connect(endpoint: string): Promise<ApiPromise> {
+    if (!this.api) {
+      const provider = new WsProvider(endpoint);
+      this.api = await ApiPromise.create({ provider });
+      await this.api.isReady;
+    }
+    return this.api;
+  }
+}


### PR DESCRIPTION
## Summary
- implement a Polkadot service for connecting to a node
- add helper to hash AI outputs and send them to the `decisions` pallet
- expose an `anchorDecision` function to integrate hashing and chain submission

## Testing
- `npm test --prefix ai-matcher-service` *(fails: cannot find package.json)*
- `pytest ai-matcher-service/tests` *(fails: SyntaxError in test placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68764398f9b48320a7e69cd65cba70db