### PR TITLE
Add multi-agent coordination layer

### DIFF
--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+#  test_matcher.py - placeholder or stub for chai-vc-platform

--- a/backend/src/multi_agent/coordinator.py
+++ b/backend/src/multi_agent/coordinator.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Simple multi-agent coordination using LangChain."""
+
+from dataclasses import dataclass
+from langchain_community.llms.fake import FakeListLLM
+from langchain.chains import LLMChain, SimpleSequentialChain
+from langchain.prompts import PromptTemplate
+
+@dataclass
+class AgentStep:
+    """Represents a single step performed by a specialist agent."""
+    name: str
+    prompt: str
+
+    def chain(self, llm: FakeListLLM) -> LLMChain:
+        template = PromptTemplate.from_template(self.prompt)
+        return LLMChain(llm=llm, prompt=template)
+
+class Coordinator:
+    """Coordinates issuance, verification and risk agents."""
+
+    def __init__(self) -> None:
+        # Fake responses to avoid external API calls
+        self.llm = FakeListLLM(responses=[
+            "issued",
+            "verified",
+            "risk_assessed",
+        ])
+        issuance = AgentStep(
+            name="issuance",
+            prompt="Issuance specialist processes: {input}",
+        )
+        verification = AgentStep(
+            name="verification",
+            prompt="Verification specialist checks: {input}",
+        )
+        risk = AgentStep(
+            name="risk",
+            prompt="Risk specialist reviews: {input}",
+        )
+        self.chain = SimpleSequentialChain(
+            chains=[
+                issuance.chain(self.llm),
+                verification.chain(self.llm),
+                risk.chain(self.llm),
+            ],
+            verbose=True,
+        )
+
+    def process(self, payload: str) -> str:
+        """Run the payload through the specialists."""
+        return self.chain.run(payload)
+
+
+def demo() -> None:
+    """Run a simple demonstration of the coordinator."""
+    coord = Coordinator()
+    result = coord.process("new credential application")
+    print("Final result:", result)
+
+
+if __name__ == "__main__":
+    demo()

--- a/backend/tests/test_coordinator.py
+++ b/backend/tests/test_coordinator.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+# Add the backend/src directory to the path for imports
+sys.path.append(str(Path(__file__).resolve().parents[2] / 'backend' / 'src'))
+
+from multi_agent.coordinator import Coordinator
+
+
+def test_coordinator_sequence():
+    coord = Coordinator()
+    result = coord.process("sample payload")
+    assert result == "risk_assessed"


### PR DESCRIPTION
## Summary
- implement a simple coordination layer using LangChain
- add tests for the multi-agent flow
- fix Python test comment so `pytest` runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687643a75fe883208106ad288a4abcb0