### PR TITLE
Add prompt A/B testing workflow

### DIFF
--- a/.github/workflows/prompt_ab_test.yml
+++ b/.github/workflows/prompt_ab_test.yml
@@ -1,0 +1,25 @@
+name: Prompt A/B Testing
+
+on:
+  pull_request:
+    paths:
+      - 'prompts/**'
+      - 'scripts/**'
+      - '.github/workflows/prompt_ab_test.yml'
+
+jobs:
+  ab-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Run A/B tests
+        run: python scripts/prompt_ab_test.py
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: ab-test-results
+          path: reports/ab_test_results.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+reports/
+__pycache__/

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,2 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+def test_placeholder():
+    assert True

--- a/prompts/prompt_v1.txt
+++ b/prompts/prompt_v1.txt
@@ -1,0 +1,1 @@
+Prompt version 1 placeholder

--- a/prompts/prompt_v2.txt
+++ b/prompts/prompt_v2.txt
@@ -1,0 +1,1 @@
+Prompt version 2 placeholder

--- a/scripts/prompt_ab_test.py
+++ b/scripts/prompt_ab_test.py
@@ -1,0 +1,31 @@
+import os
+import json
+import random
+
+PROMPTS_DIR = os.path.join(os.path.dirname(__file__), '..', 'prompts')
+REPORTS_DIR = os.path.join(os.path.dirname(__file__), '..', 'reports')
+
+
+def evaluate_prompt(prompt_text: str) -> float:
+    """Return a dummy score for the prompt."""
+    random.seed(hash(prompt_text) % 2**32)
+    return random.random()
+
+
+def main():
+    results = {}
+    for name in sorted(os.listdir(PROMPTS_DIR)):
+        if name.endswith('.txt'):
+            with open(os.path.join(PROMPTS_DIR, name)) as f:
+                text = f.read().strip()
+            score = evaluate_prompt(text)
+            results[name] = score
+            print(f"{name}: {score:.4f}")
+
+    os.makedirs(REPORTS_DIR, exist_ok=True)
+    with open(os.path.join(REPORTS_DIR, 'ab_test_results.json'), 'w') as f:
+        json.dump(results, f, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/version_prompt.py
+++ b/scripts/version_prompt.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+PROMPTS_DIR = os.path.join(os.path.dirname(__file__), '..', 'prompts')
+
+
+def get_next_version() -> int:
+    versions = []
+    for name in os.listdir(PROMPTS_DIR):
+        if name.startswith('prompt_v') and name.endswith('.txt'):
+            try:
+                versions.append(int(name[len('prompt_v'):-4]))
+            except ValueError:
+                pass
+    return max(versions) + 1 if versions else 1
+
+
+def main():
+    if len(sys.argv) < 2:
+        print('Usage: version_prompt.py "prompt text"')
+        sys.exit(1)
+    version = get_next_version()
+    filename = os.path.join(PROMPTS_DIR, f'prompt_v{version}.txt')
+    with open(filename, 'w') as f:
+        f.write(sys.argv[1])
+    print(f'Created {filename}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add placeholder prompts
- add scripts for prompt A/B testing and versioning
- configure GitHub Actions workflow for prompt testing
- ignore reports and pycache
- fix Python test placeholder for CI

## Testing
- `pytest -q`
- `python scripts/prompt_ab_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68765c3ed70483208f2e32a2c455e5bc