### PR TITLE
Implement feedback collector service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+*.log
+feedback_service/feedback.csv

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Feedback Service
+
+The `feedback_service` collects hiring outcomes so the matching models can be improved over time. It exposes a small FastAPI app with a single endpoint:
+
+```
+POST /feedback
+{
+  "candidate_id": "c1",
+  "job_id": "j1",
+  "outcome": "hired",
+  "notes": "optional notes"
+}
+```
+
+Records are appended to `feedback_service/feedback.csv` and can later be used to retrain the matching algorithms.
+
+Run the tests with:
+
+```
+pytest -q
+```

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,4 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# Placeholder test for matcher service
+
+def test_placeholder():
+    assert True

--- a/feedback_service/main.py
+++ b/feedback_service/main.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from datetime import datetime
+import csv
+import os
+
+app = FastAPI()
+
+FEEDBACK_FILE = os.path.join(os.path.dirname(__file__), "feedback.csv")
+
+class Feedback(BaseModel):
+    candidate_id: str
+    job_id: str
+    outcome: str
+    notes: str | None = None
+
+@app.post("/feedback")
+def collect_feedback(feedback: Feedback):
+    file_exists = os.path.isfile(FEEDBACK_FILE)
+    try:
+        with open(FEEDBACK_FILE, "a", newline="") as f:
+            writer = csv.writer(f)
+            if not file_exists:
+                writer.writerow(["timestamp", "candidate_id", "job_id", "outcome", "notes"])
+            writer.writerow([
+                datetime.utcnow().isoformat(),
+                feedback.candidate_id,
+                feedback.job_id,
+                feedback.outcome,
+                feedback.notes or "",
+            ])
+        return {"status": "recorded"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/")
+def read_root():
+    return {"status": "feedback service running"}

--- a/feedback_service/tests/test_feedback.py
+++ b/feedback_service/tests/test_feedback.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+from pathlib import Path
+import csv
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import main  # type: ignore
+
+client = TestClient(main.app)
+
+
+def test_collect_feedback(tmp_path, monkeypatch):
+    feedback_file = tmp_path / "feedback.csv"
+    monkeypatch.setattr(main, "FEEDBACK_FILE", str(feedback_file))
+
+    response = client.post(
+        "/feedback",
+        json={"candidate_id": "c1", "job_id": "j1", "outcome": "hired", "notes": "great fit"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "recorded"
+
+    with open(feedback_file, newline="") as f:
+        rows = list(csv.reader(f))
+
+    assert rows[0] == ["timestamp", "candidate_id", "job_id", "outcome", "notes"]
+    assert rows[1][1:] == ["c1", "j1", "hired", "great fit"]


### PR DESCRIPTION
## Summary
- add `feedback_service` FastAPI microservice that records hiring feedback to `feedback.csv`
- implement tests for feedback collection
- fix placeholder matcher test
- document the feedback service in README
- add `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765c7bd0fc8320a73a9a0fb8dee64f