### PR TITLE
Add cosign image signing and policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,1 +1,7 @@
 // ci.yml - placeholder or stub for chai-vc-platform
+# Build and sign Docker images with cosign
+# jobs:
+#   build:
+#     steps:
+#       - run: docker build -t myimage .
+#       - run: ./scripts/cosign-sign.sh myimage

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore cosign private keys
+cosign.key

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Docker Image Signing
+
+This repository includes a script for signing Docker images with [cosign](https://docs.sigstore.dev/cosign/overview/). After building an image, run:
+
+```bash
+./scripts/cosign-sign.sh <your-image>
+```
+
+The script expects `COSIGN_KEY` to reference your signing key. The resulting signature can be verified by Kubernetes using the policy controller.
+
+## Admission Policy
+
+A sample `ClusterImagePolicy` is provided in `k8s/cosign-policy.yaml`. Apply it to your cluster to reject unsigned images:
+
+```bash
+kubectl apply -f k8s/cosign-policy.yaml
+```
+
+Make sure the corresponding public key is stored in the `cosign-public-key` secret.

--- a/k8s/cosign-policy.yaml
+++ b/k8s/cosign-policy.yaml
@@ -1,0 +1,12 @@
+# ClusterImagePolicy requiring cosign signatures
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: require-cosign-signature
+spec:
+  images:
+  - glob: "docker.io/myorg/*"
+  authorities:
+  - key:
+      secretRef:
+        name: cosign-public-key

--- a/scripts/cosign-sign.sh
+++ b/scripts/cosign-sign.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Simple script to sign a Docker image using cosign.
+# Usage: ./cosign-sign.sh <image>
+set -euo pipefail
+IMAGE="$1"
+cosign sign --key "${COSIGN_KEY:-cosign.key}" "$IMAGE"


### PR DESCRIPTION
## Summary
- add a cosign signing script
- add a ClusterImagePolicy example
- document how to sign Docker images and apply the policy
- sketch CI steps for cosign image signing
- ignore private cosign keys

## Testing
- `pytest` *(fails: SyntaxError in placeholder test file)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6875b9c26b5c8320a00c8c6bb27cbcfb