### PR TITLE
Add Helmet security headers for Next.js frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Development
+
+### Frontend
+
+Install dependencies and start the Next.js server with hardened security headers:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "helmet": "^7.0.0",
+    "next": "^13.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,0 +1,19 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+          <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none';" />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const next = require('next');
+const helmet = require('helmet');
+
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+app.prepare().then(() => {
+  const server = express();
+
+  server.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"],
+          imgSrc: ["'self'", 'data:', 'https:'],
+          connectSrc: ["'self'", 'https:'],
+          fontSrc: ["'self'", 'https:', 'data:'],
+          frameAncestors: ["'none'"]
+        }
+      },
+      referrerPolicy: { policy: 'no-referrer' },
+      frameguard: { action: 'deny' }
+    })
+  );
+
+  server.all('*', (req, res) => handle(req, res));
+
+  const port = process.env.PORT || 3000;
+  server.listen(port, err => {
+    if (err) throw err;
+    console.log(`> Ready on http://localhost:${port}`);
+  });
+});


### PR DESCRIPTION
## Summary
- set up a basic Next.js server with Express
- apply Helmet middleware with a strict CSP
- inject a CSP meta tag via `_document.tsx`
- document how to run the frontend

## Testing
- `npm test` *(fails: Missing script)*
- `pytest` *(fails: SyntaxError in placeholder test)*

------
https://chatgpt.com/codex/tasks/task_e_6875b39463f48320aad32cf2d24a1557