### PR TITLE
Add explanation generator via OpenAI

### DIFF
--- a/ai-matcher-service/src/explainer.py
+++ b/ai-matcher-service/src/explainer.py
@@ -1,0 +1,32 @@
+import os
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - optional dependency
+    openai = None
+
+def generate_human_readable_explanation(decision: dict) -> str:
+    """Generate a human readable explanation for an anchored decision.
+
+    If the OpenAI package and API key are available, the function will
+    delegate explanation generation to the GPT API. Otherwise it falls
+    back to a simple formatted string.
+    """
+    prompt = (
+        "Provide a human readable explanation for the following anchored "
+        f"decision: {decision}"
+    )
+    api_key = os.getenv("OPENAI_API_KEY")
+
+    if openai and api_key:
+        openai.api_key = api_key
+        try:
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return response.choices[0].message["content"].strip()
+        except Exception:
+            return f"Explanation for {decision}"
+
+    return f"Explanation for {decision}"

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,13 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+import os
+import sys
+
+# Allow importing from the src directory
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from explainer import generate_human_readable_explanation
+
+def test_generate_human_readable_explanation():
+    decision = {"status": "approved", "anchor": "proof123"}
+    explanation = generate_human_readable_explanation(decision)
+    assert isinstance(explanation, str)
+    assert explanation


### PR DESCRIPTION
## Summary
- create `explainer.py` in the matcher service to generate a human-readable explanation for anchored decisions using OpenAI when available
- expose src as a package and update matcher test

## Testing
- `pytest -q ai-matcher-service/tests/test_matcher.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876439f67508320ac72485128787307