### PR TITLE
Add offline credential simulation environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Simulation Environment
+
+A lightweight simulator for offline credentialing scenarios is available in the `simulation` directory. See `simulation/README.md` for usage details.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,4 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform
+
+def test_placeholder():
+    assert True

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -1,0 +1,22 @@
+# Simulation Environment
+
+This directory contains a lightweight simulator that allows AI agents to run "what-if" credentialing scenarios offline.
+
+## Running a scenario
+
+Execute the simulator with a scenario file:
+
+```bash
+python credential_scenario_simulator.py scenarios/example.json
+```
+
+The simulator will process the actions defined in the scenario and print the result of each step.
+
+## Scenario format
+
+A scenario file is JSON containing a list of `credentials` and `actions`. Actions can include:
+
+- `verify` – check the current status of a credential.
+- `revoke` – mark a credential as revoked.
+
+See `scenarios/example.json` for a reference structure.

--- a/simulation/credential_scenario_simulator.py
+++ b/simulation/credential_scenario_simulator.py
@@ -1,0 +1,63 @@
+"""Simple offline simulator for credentialing scenarios."""
+
+import json
+from dataclasses import dataclass
+from typing import Dict, List
+
+@dataclass
+class Credential:
+    id: str
+    issuer: str
+    subject: str
+    status: str
+
+def load_scenario(path: str) -> Dict:
+    with open(path, 'r') as f:
+        return json.load(f)
+
+def run_scenario(data: Dict) -> List[Dict]:
+    credentials = [Credential(**c) for c in data.get('credentials', [])]
+    actions = data.get('actions', [])
+    results = []
+    for action in actions:
+        cred = next((c for c in credentials if c.id == action.get('credential_id')), None)
+        if not cred:
+            results.append({
+                'action': action.get('type'),
+                'credential_id': action.get('credential_id'),
+                'result': 'credential not found'
+            })
+            continue
+        if action.get('type') == 'revoke':
+            cred.status = 'revoked'
+            results.append({
+                'action': 'revoke',
+                'credential_id': cred.id,
+                'result': 'revoked'
+            })
+        elif action.get('type') == 'verify':
+            results.append({
+                'action': 'verify',
+                'credential_id': cred.id,
+                'result': cred.status
+            })
+        else:
+            results.append({
+                'action': action.get('type'),
+                'credential_id': cred.id,
+                'result': 'unknown action'
+            })
+    return results
+
+def main(scenario_path: str) -> None:
+    data = load_scenario(scenario_path)
+    results = run_scenario(data)
+    for r in results:
+        print(f"{r['action']} {r['credential_id']}: {r['result']}")
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Run credentialing scenario offline.')
+    parser.add_argument('scenario', help='Path to scenario JSON file')
+    args = parser.parse_args()
+    main(args.scenario)

--- a/simulation/scenarios/example.json
+++ b/simulation/scenarios/example.json
@@ -1,0 +1,15 @@
+{
+  "credentials": [
+    {
+      "id": "cred1",
+      "issuer": "Hospital A",
+      "subject": "Doctor D",
+      "status": "active"
+    }
+  ],
+  "actions": [
+    {"type": "verify", "credential_id": "cred1"},
+    {"type": "revoke", "credential_id": "cred1"},
+    {"type": "verify", "credential_id": "cred1"}
+  ]
+}

--- a/simulation/tests/test_simulation.py
+++ b/simulation/tests/test_simulation.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from credential_scenario_simulator import run_scenario
+
+
+def test_run_scenario():
+    data = {
+        "credentials": [
+            {"id": "c1", "issuer": "X", "subject": "Y", "status": "active"}
+        ],
+        "actions": [
+            {"type": "verify", "credential_id": "c1"},
+            {"type": "revoke", "credential_id": "c1"},
+            {"type": "verify", "credential_id": "c1"}
+        ]
+    }
+    results = run_scenario(data)
+    assert results[0]["result"] == "active"
+    assert results[1]["result"] == "revoked"
+    assert results[2]["result"] == "revoked"


### PR DESCRIPTION
## Summary
- add a simple scenario simulator so AI agents can run credentialing "what-if" tests offline
- document how to run the simulator
- update placeholder test to pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765c338cd483208d20cca9dff25270