### PR TITLE
Implement pricing agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Pricing Agent
+
+The `ai-matcher-service` includes a simple pricing agent that adjusts fees and staking
+rates based on real-time demand metrics. See `ai-matcher-service/src/pricing/price_agent.py`
+for implementation details.

--- a/ai-matcher-service/src/__init__.py
+++ b/ai-matcher-service/src/__init__.py
@@ -1,0 +1,1 @@
+# Package for AI services

--- a/ai-matcher-service/src/pricing/__init__.py
+++ b/ai-matcher-service/src/pricing/__init__.py
@@ -1,0 +1,1 @@
+# Pricing module

--- a/ai-matcher-service/src/pricing/price_agent.py
+++ b/ai-matcher-service/src/pricing/price_agent.py
@@ -1,0 +1,33 @@
+import math
+from dataclasses import dataclass
+
+@dataclass
+class DemandMetrics:
+    volume: float
+    volatility: float
+
+
+def compute_fee(metrics: DemandMetrics) -> float:
+    """Compute a transaction fee based on demand metrics."""
+    base_fee = 0.02  # 2% base
+    demand_factor = metrics.volume / 1000.0
+    volatility_factor = metrics.volatility / 100.0
+    fee = base_fee + 0.01 * demand_factor + 0.01 * volatility_factor
+    return min(fee, 1.0)
+
+
+def compute_staking_rate(metrics: DemandMetrics) -> float:
+    """Compute a staking reward rate based on demand metrics."""
+    base_rate = 0.05  # 5% base
+    demand_factor = metrics.volume / 1000.0
+    volatility_factor = metrics.volatility / 100.0
+    rate = base_rate + 0.02 * demand_factor - 0.01 * volatility_factor
+    return max(0.0, min(rate, 0.2))
+
+
+def adjust_pricing(metrics: DemandMetrics) -> dict:
+    """Return pricing adjustments for given demand metrics."""
+    return {
+        "fee": compute_fee(metrics),
+        "staking_rate": compute_staking_rate(metrics),
+    }

--- a/ai-matcher-service/tests/test_price_agent.py
+++ b/ai-matcher-service/tests/test_price_agent.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from pricing.price_agent import (
+    compute_fee,
+    compute_staking_rate,
+    adjust_pricing,
+    DemandMetrics,
+)
+
+
+def test_adjust_pricing():
+    metrics = DemandMetrics(volume=500, volatility=20)
+    pricing = adjust_pricing(metrics)
+    assert 0 < pricing["fee"] <= 1
+    assert 0 <= pricing["staking_rate"] <= 0.2


### PR DESCRIPTION
## Summary
- add Python pricing agent that adjusts fees and staking rates
- document pricing agent
- test pricing calculations

## Testing
- `pytest -q ai-matcher-service/tests/test_price_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68765c96ab448320aad4744747b1ff89