### PR TITLE
Add GPT onboarding chatbot service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Chatbot Service
+
+A simple GPT-powered self-service chatbot is provided for user onboarding and wallet recovery. The service is implemented in `backend/src/chatbot` and exposes a `/chat` endpoint.
+
+### Running the chatbot
+
+1. Install dependencies:
+   ```bash
+   npm install express openai
+   ```
+2. Set the `OPENAI_API_KEY` environment variable with your OpenAI API key.
+3. Start the service using `ts-node` or a compiled build:
+   ```bash
+   npx ts-node backend/src/chatbot/server.ts
+   ```
+4. Send a POST request to `http://localhost:3001/chat` with a JSON body:
+   ```json
+   { "message": "How do I recover my wallet?" }
+   ```
+   The response will contain the assistant's reply.

--- a/backend/src/chatbot/chatbot.ts
+++ b/backend/src/chatbot/chatbot.ts
@@ -1,0 +1,28 @@
+import { Configuration, OpenAIApi } from "openai";
+
+export class Chatbot {
+  private openai: OpenAIApi;
+
+  constructor(apiKey: string) {
+    const config = new Configuration({ apiKey });
+    this.openai = new OpenAIApi(config);
+  }
+
+  async ask(message: string): Promise<string> {
+    const response = await this.openai.createChatCompletion({
+      model: "gpt-3.5-turbo",
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are an onboarding assistant that helps users register and recover wallets.",
+        },
+        { role: "user", content: message },
+      ],
+    });
+
+    return (
+      response.data.choices[0]?.message?.content?.trim() || ""
+    );
+  }
+}

--- a/backend/src/chatbot/server.ts
+++ b/backend/src/chatbot/server.ts
@@ -1,0 +1,28 @@
+import express from "express";
+import { Chatbot } from "./chatbot";
+
+const app = express();
+app.use(express.json());
+
+const apiKey = process.env.OPENAI_API_KEY || "";
+const bot = new Chatbot(apiKey);
+
+app.post("/chat", async (req, res) => {
+  const message = req.body.message;
+  if (!message) {
+    return res.status(400).json({ error: "Missing message" });
+  }
+
+  try {
+    const reply = await bot.ask(message);
+    res.json({ reply });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Failed to get reply" });
+  }
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`Chatbot service running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- introduce an OpenAI-based chatbot for onboarding and wallet recovery
- document how to run the chatbot service

## Testing
- `pytest -q` *(fails: SyntaxError in ai-matcher-service/tests/test_matcher.py)*

------
https://chatgpt.com/codex/tasks/task_e_68765cccedcc8320b00fd821cdbddd48