### PR TITLE
Add AI-augmented docs generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Documentation Generator
+
+Run `python scripts/generate_docs.py` to update `docs/DEV_PORTAL.md` with summaries of code documentation.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,4 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform
+
+def test_placeholder():
+    assert True

--- a/docs/DEV_PORTAL.md
+++ b/docs/DEV_PORTAL.md
@@ -1,0 +1,4 @@
+# Dev Portal Documentation
+
+Generated summary of codebase documentation.
+

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -1,0 +1,66 @@
+import os
+import re
+import ast
+from pathlib import Path
+from sumy.parsers.plaintext import PlaintextParser
+from sumy.nlp.tokenizers import Tokenizer
+from sumy.summarizers.lsa import LsaSummarizer
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_FILE = REPO_ROOT / 'docs' / 'DEV_PORTAL.md'
+
+PYTHON_EXT = '.py'
+TYPESCRIPT_EXT = '.ts'
+
+
+def extract_python_docstrings(file_path: Path) -> str:
+    try:
+        source = file_path.read_text()
+        mod = ast.parse(source)
+        doc = ast.get_docstring(mod) or ''
+        return doc
+    except Exception:
+        return ''
+
+
+def extract_ts_comments(file_path: Path) -> str:
+    text = file_path.read_text()
+    comments = re.findall(r'/\*\*(.*?)\*/', text, re.S)
+    return '\n'.join(comment.strip() for comment in comments)
+
+
+def summarize(text: str, sentences: int = 3) -> str:
+    if not text.strip():
+        return ''
+    parser = PlaintextParser.from_string(text, Tokenizer('english'))
+    summarizer = LsaSummarizer()
+    summary = summarizer(parser.document, sentences)
+    return ' '.join(str(sent) for sent in summary)
+
+
+def gather_docs() -> str:
+    docs = []
+    for path in REPO_ROOT.rglob('*'):
+        if path.suffix == PYTHON_EXT:
+            doc = extract_python_docstrings(path)
+            summary = summarize(doc)
+            if summary:
+                docs.append(f'### {path.relative_to(REPO_ROOT)}\n{summary}\n')
+        elif path.suffix == TYPESCRIPT_EXT:
+            doc = extract_ts_comments(path)
+            summary = summarize(doc)
+            if summary:
+                docs.append(f'### {path.relative_to(REPO_ROOT)}\n{summary}\n')
+    return '\n'.join(docs)
+
+
+def main():
+    content = '# Dev Portal Documentation\n\n'
+    content += 'Generated summary of codebase documentation.\n\n'
+    content += gather_docs()
+    OUTPUT_FILE.write_text(content)
+    print(f'Documentation written to {OUTPUT_FILE}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a minimal docs generator script that summarizes docstrings using `sumy`
- describe generator usage in README
- provide placeholder test to keep pytest green

## Testing
- `pytest -q`
- `python scripts/generate_docs.py`

------
https://chatgpt.com/codex/tasks/task_e_68765cf7435883208ba06a1187025e2b