### PR TITLE
Add smart contract skeletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Smart Contracts
+
+The `contracts` directory contains Solidity contracts that demonstrate how on-chain
+verification and trust management can be handled:
+
+* `ProofVerifier.sol` &ndash; verifies credential hashes and checks revocation status.
+* `TrustRegistry.sol` &ndash; simple trust registry allowing issuers to accumulate
+  reputation through endorsement votes.
+* `SelectiveDisclosureVerifier.sol` &ndash; skeleton for integrating zero-knowledge
+  proof verification to enable selective attribute disclosure.
+
+These contracts are minimal examples and are intended as a starting point for a
+full blockchain-based credential platform.

--- a/contracts/IVerifier.sol
+++ b/contracts/IVerifier.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title IVerifier
+ * @notice Interface for zk-SNARK verifier contracts.
+ */
+interface IVerifier {
+    function verifyProof(bytes memory proof, uint256[] memory pubSignals) external view returns (bool);
+}

--- a/contracts/ProofVerifier.sol
+++ b/contracts/ProofVerifier.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title ProofVerifier
+ * @notice Basic verification contract that checks a credential hash and verifies
+ *         revocation status. This is a simplified skeleton used for demonstration
+ *         purposes within chai-vc-platform.
+ */
+contract ProofVerifier {
+    // mapping of credential hash to revocation status
+    mapping(bytes32 => bool) public revoked;
+
+    /**
+     * @notice Mark a credential as revoked.
+     * @param credentialHash Hash of the credential to revoke.
+     */
+    function revokeCredential(bytes32 credentialHash) external {
+        revoked[credentialHash] = true;
+    }
+
+    /**
+     * @notice Verify a credential hash and ensure it has not been revoked.
+     * @param credentialHash Hash of the credential to verify.
+     * @return valid True if the credential exists and is not revoked.
+     */
+    function verifyProof(bytes32 credentialHash) external view returns (bool valid) {
+        // In a real implementation there would be additional signature and proof checks
+        return !revoked[credentialHash];
+    }
+}

--- a/contracts/SelectiveDisclosureVerifier.sol
+++ b/contracts/SelectiveDisclosureVerifier.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title SelectiveDisclosureVerifier
+ * @notice Skeleton contract demonstrating how a zero-knowledge proof verifier
+ *         could be integrated for selective attribute disclosure. The actual ZKP
+ *         verification would rely on an external library or verifier contract
+ *         generated from a circuit (e.g. Groth16 via snarkjs).
+ */
+import "./IVerifier.sol";
+
+contract SelectiveDisclosureVerifier {
+    // deployed verifier contract generated from a ZKP circuit
+    IVerifier public zkVerifier;
+
+    constructor(address _zkVerifier) {
+        zkVerifier = IVerifier(_zkVerifier);
+    }
+
+    /**
+     * @notice Verify a zero-knowledge proof allowing selective disclosure of attributes.
+     * @param proof Encoded zk-SNARK proof data.
+     * @param publicInputs Public inputs related to the disclosed attributes.
+     * @return valid True if the proof is valid according to the circuit.
+     */
+    function verify(bytes memory proof, uint256[] memory publicInputs) public view returns (bool valid) {
+        // The actual call would forward the proof and inputs to the verifier contract
+        // return zkVerifier.verifyProof(proof, publicInputs);
+        valid = false; // placeholder return for compilation
+    }
+}

--- a/contracts/TrustRegistry.sol
+++ b/contracts/TrustRegistry.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title TrustRegistry
+ * @notice Registry that tracks issuer reputation and endorsement votes.
+ *         This simplified contract allows issuers to register and other
+ *         participants to endorse them with reputation weights.
+ */
+contract TrustRegistry {
+    struct Issuer {
+        uint256 reputation;
+        mapping(address => uint256) endorsements;
+        bool exists;
+    }
+
+    mapping(address => Issuer) private issuers;
+
+    event IssuerRegistered(address indexed issuer);
+    event IssuerEndorsed(address indexed issuer, address indexed endorser, uint256 weight);
+
+    /**
+     * @notice Register an issuer in the trust registry.
+     */
+    function registerIssuer() external {
+        require(!issuers[msg.sender].exists, "already registered");
+        issuers[msg.sender].exists = true;
+        emit IssuerRegistered(msg.sender);
+    }
+
+    /**
+     * @notice Endorse an issuer with a reputation weight.
+     * @param issuer Address of the issuer to endorse.
+     * @param weight Numeric weight representing the strength of endorsement.
+     */
+    function endorseIssuer(address issuer, uint256 weight) external {
+        require(issuers[issuer].exists, "issuer not registered");
+        issuers[issuer].endorsements[msg.sender] = weight;
+        issuers[issuer].reputation += weight;
+        emit IssuerEndorsed(issuer, msg.sender, weight);
+    }
+
+    /**
+     * @notice Get the reputation score for an issuer.
+     * @param issuer Address of the issuer.
+     */
+    function getReputation(address issuer) external view returns (uint256) {
+        return issuers[issuer].reputation;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ProofVerifier` contract for credential hash validation and revocation
- add `TrustRegistry` with basic reputation and endorsement logic
- add a placeholder interface and selective-disclosure verifier contract
- document new contracts in README

## Testing
- `Running placeholder tests`

------
https://chatgpt.com/codex/tasks/task_e_68766724affc8320a48974ae33f0a259