### PR TITLE
Add credential expiry extrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Blockchain support
+
+The `PolkadotService` provides convenience helpers for building extrinsics.
+Two new helpers are available:
+
+- `createCredentialExpiryExtrinsic` &ndash; store credential expiry on chain.
+- `createLicenseRenewalReminderExtrinsic` &ndash; set up a reminder before expiry.

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,51 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+import { ApiPromise, WsProvider, SubmittableExtrinsic } from '@polkadot/api';
+
+// Basic Polkadot service for interacting with a chain.
+export class PolkadotService {
+  private api: ApiPromise | null = null;
+
+  /** Initialize the API connection. */
+  async init(endpoint: string): Promise<void> {
+    const provider = new WsProvider(endpoint);
+    this.api = await ApiPromise.create({ provider });
+  }
+
+  private ensureApi(): ApiPromise {
+    if (!this.api) {
+      throw new Error('Polkadot API not initialized');
+    }
+    return this.api;
+  }
+
+  /**
+   * Create an extrinsic that sets the expiry time for a credential.
+   * @param credentialId Identifier of the credential.
+   * @param expiryUnix Expiry timestamp (in seconds since epoch).
+   */
+  createCredentialExpiryExtrinsic(
+    credentialId: string,
+    expiryUnix: number
+  ): SubmittableExtrinsic<'promise'> {
+    const api = this.ensureApi();
+    return api.tx.credentials.setExpiry(credentialId, expiryUnix);
+  }
+
+  /**
+   * Create an extrinsic that stores a renewal reminder for a credential.
+   * @param credentialId Identifier of the credential.
+   * @param expiryUnix Expiry timestamp of the credential.
+   * @param daysBefore Number of days before expiry to trigger the reminder.
+   */
+  createLicenseRenewalReminderExtrinsic(
+    credentialId: string,
+    expiryUnix: number,
+    daysBefore: number
+  ): SubmittableExtrinsic<'promise'> {
+    const api = this.ensureApi();
+    return api.tx.credentials.setRenewalReminder(
+      credentialId,
+      expiryUnix,
+      daysBefore
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement Polkadot service helpers for credential expiry and renewal reminders
- document new extrinsics in README

## Testing
- `pytest -q` *(fails: SyntaxError in placeholder test_matcher.py)*

------
https://chatgpt.com/codex/tasks/task_e_68766888308c832091645e99c9dc296f