### PR TITLE
Add BBS+ wallet demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## BBS+ Wallet Demo
+
+A minimal wallet demo using [BBS+ signatures](https://github.com/mattrglobal/bbs-signatures) is available under `wallet/`. The demo shows how to create a key pair, sign a credential and derive a field-level proof.
+
+Run the demo with:
+
+```bash
+node wallet/demo.js
+```
+
+The script will output the base64 encoded signature and a proof revealing only the first field of the credential.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "chai-vc-platform",
+  "version": "1.0.0",
+  "description": "End-to-end healthcare credentialing and hiring verification.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "demo": "node wallet/demo.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@mattrglobal/bbs-signatures": "^2.0.0"
+  }
+}

--- a/wallet/bbs_wallet.js
+++ b/wallet/bbs_wallet.js
@@ -1,0 +1,35 @@
+const {
+  generateBls12381G2KeyPair,
+  blsSign,
+  blsCreateProof
+} = require('@mattrglobal/bbs-signatures');
+
+function encodeMessage(message) {
+  return Uint8Array.from(Buffer.from(String(message), 'utf-8'));
+}
+
+async function generateKeyPair() {
+  return await generateBls12381G2KeyPair();
+}
+
+async function signCredential({ keyPair, credential }) {
+  const messages = Object.values(credential).map(encodeMessage);
+  const signature = await blsSign({ keyPair, messages });
+  return { signature, messages };
+}
+
+async function deriveProof({ keyPair, signature, messages, revealIndexes, nonce }) {
+  return await blsCreateProof({
+    signature,
+    publicKey: keyPair.publicKey,
+    messages,
+    nonce: encodeMessage(nonce || 'nonce'),
+    revealed: revealIndexes,
+  });
+}
+
+module.exports = {
+  generateKeyPair,
+  signCredential,
+  deriveProof,
+};

--- a/wallet/demo.js
+++ b/wallet/demo.js
@@ -1,0 +1,16 @@
+const { generateKeyPair, signCredential, deriveProof } = require('./bbs_wallet');
+
+(async () => {
+  const credential = { name: 'Alice', age: '30', role: 'Nurse' };
+  const keyPair = await generateKeyPair();
+  const { signature, messages } = await signCredential({ keyPair, credential });
+  console.log('Signature:', Buffer.from(signature).toString('base64'));
+  const proof = await deriveProof({
+    keyPair,
+    signature,
+    messages,
+    revealIndexes: [0],
+    nonce: 'example nonce',
+  });
+  console.log('Proof:', Buffer.from(proof).toString('base64'));
+})();


### PR DESCRIPTION
## Summary
- integrate BBS+ library via npm
- add simple wallet API to sign credentials and derive field-level proofs
- document how to run the demo

## Testing
- `node wallet/demo.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876687f42008320a6b96bdeb87cbede