### PR TITLE
Add GPT feedback widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Feedback
+
+User suggestions can be submitted on `/feedback`. Suggestions are summarized by the GPT-powered API route at `/api/feedback`.

--- a/frontend/pages/api/feedback.ts
+++ b/frontend/pages/api/feedback.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { Configuration, OpenAIApi } from 'openai'
+
+const configuration = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY || '',
+})
+const openai = new OpenAIApi(configuration)
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end()
+  }
+
+  const { message } = req.body
+
+  try {
+    const completion = await openai.createChatCompletion({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You summarize user feedback.' },
+        { role: 'user', content: String(message) },
+      ],
+    })
+    const reply = completion.data.choices[0]?.message?.content?.trim() || ''
+    res.status(200).json({ reply })
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to process feedback' })
+  }
+}

--- a/frontend/pages/feedback.tsx
+++ b/frontend/pages/feedback.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+
+export default function Feedback() {
+  const [message, setMessage] = useState('')
+  const [reply, setReply] = useState('')
+
+  const sendFeedback = async () => {
+    const res = await fetch('/api/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message }),
+    })
+    const data = await res.json()
+    if (data.reply) {
+      setReply(data.reply)
+    }
+  }
+
+  return (
+    <div>
+      <h1>User Feedback</h1>
+      <textarea
+        value={message}
+        onChange={e => setMessage(e.target.value)}
+        placeholder="Enter your suggestion here"
+      />
+      <button onClick={sendFeedback}>Submit Feedback</button>
+      {reply && <p>{reply}</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a simple Feedback page on the frontend
- implement `/api/feedback` route that uses OpenAI to summarize input
- document feedback endpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68806b2cae5c8320a863ab79ca963011