### PR TITLE
Add basic SDKs for credential issuance

### DIFF
--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.chai</groupId>
+    <artifactId>credential-sdk-java</artifactId>
+    <version>0.1.0</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sdk/java/src/main/java/com/chai/sdk/CredentialSDK.java
+++ b/sdk/java/src/main/java/com/chai/sdk/CredentialSDK.java
@@ -1,0 +1,34 @@
+package com.chai.sdk;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class CredentialSDK {
+    public static class Credential {
+        public final String payload;
+        public final String signature;
+        public Credential(String payload, String signature) {
+            this.payload = payload;
+            this.signature = signature;
+        }
+    }
+
+    public static Credential issueCredential(String payload, String secret) throws Exception {
+        String signature = sign(payload, secret);
+        return new Credential(payload, signature);
+    }
+
+    public static boolean validateCredential(Credential credential, String secret) throws Exception {
+        String expected = sign(credential.payload, secret);
+        return expected.equals(credential.signature);
+    }
+
+    private static String sign(String message, String secret) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        byte[] raw = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+        return Base64.getEncoder().encodeToString(raw);
+    }
+}

--- a/sdk/java/src/test/java/com/chai/sdk/CredentialSDKTest.java
+++ b/sdk/java/src/test/java/com/chai/sdk/CredentialSDKTest.java
@@ -1,0 +1,16 @@
+package com.chai.sdk;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CredentialSDKTest {
+    @Test
+    public void testIssueAndValidate() throws Exception {
+        String payload = "{\"id\":1}";
+        String secret = "topsecret";
+        CredentialSDK.Credential cred = CredentialSDK.issueCredential(payload, secret);
+        assertTrue(CredentialSDK.validateCredential(cred, secret));
+        CredentialSDK.Credential bad = new CredentialSDK.Credential(payload, "bad");
+        assertFalse(CredentialSDK.validateCredential(bad, secret));
+    }
+}

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "credential-sdk-js",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "credential-sdk-js",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "credential-sdk-js",
+  "version": "0.1.0",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "test": "node test/test.js"
+  }
+}

--- a/sdk/js/src/index.js
+++ b/sdk/js/src/index.js
@@ -1,0 +1,20 @@
+import crypto from 'crypto';
+
+export function issueCredential(payload, secret) {
+  const message = JSON.stringify(payload);
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(message)
+    .digest('base64');
+  return { payload, signature };
+}
+
+export function validateCredential(credential, secret) {
+  const { payload, signature } = credential;
+  const message = JSON.stringify(payload);
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(message)
+    .digest('base64');
+  return signature === expected;
+}

--- a/sdk/js/test/test.js
+++ b/sdk/js/test/test.js
@@ -1,0 +1,12 @@
+import assert from 'assert';
+import { issueCredential, validateCredential } from '../src/index.js';
+
+const payload = { id: 1, name: 'Alice' };
+const secret = 'topsecret';
+
+const credential = issueCredential(payload, secret);
+assert.ok(validateCredential(credential, secret));
+credential.signature = 'bad';
+assert.ok(!validateCredential(credential, secret));
+
+console.log('All JS SDK tests passed');

--- a/sdk/python/credential_sdk/__init__.py
+++ b/sdk/python/credential_sdk/__init__.py
@@ -1,0 +1,17 @@
+import hmac
+import json
+import hashlib
+
+
+def issue_credential(payload, secret):
+    message = json.dumps(payload, separators=(",", ":")).encode()
+    signature = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+    return {"payload": payload, "signature": signature}
+
+
+def validate_credential(credential, secret):
+    payload = credential.get("payload")
+    signature = credential.get("signature")
+    message = json.dumps(payload, separators=(",", ":")).encode()
+    expected = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+    return signature == expected

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "credential-sdk-python"
+version = "0.1.0"

--- a/sdk/python/tests/test_credential_sdk.py
+++ b/sdk/python/tests/test_credential_sdk.py
@@ -1,0 +1,10 @@
+from credential_sdk import issue_credential, validate_credential
+
+
+def test_issuance_and_validation():
+    payload = {"id": 1, "name": "Alice"}
+    secret = "topsecret"
+    cred = issue_credential(payload, secret)
+    assert validate_credential(cred, secret)
+    cred["signature"] = "bad"
+    assert not validate_credential(cred, secret)


### PR DESCRIPTION
## Summary
- implement JS, Python, and Java SDKs for credential issuance and validation using HMAC signatures
- add simple tests for each SDK

## Testing
- `cd sdk/js && npm test --silent`
- `cd sdk/python && PYTHONPATH=. pytest -q`
- `cd sdk/java && mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68806af2515083208b833c42ed8fb397