### PR TITLE
Add dev portal playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Developer Portal
+
+A basic developer portal lives in `frontend/`. A new `Playground` page provides a live code environment powered by CodeSandbox. You can access it at `/playground` when running the frontend.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/frontend/pages/playground.tsx
+++ b/frontend/pages/playground.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const PlaygroundPage: React.FC = () => (
+  <div style={{ height: '100vh' }}>
+    <iframe
+      src="https://codesandbox.io/embed/new"
+      style={{ width: '100%', height: '100%', border: 0, borderRadius: '4px', overflow: 'hidden' }}
+      title="CodeSandbox Playground"
+      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+    />
+  </div>
+);
+
+export default PlaygroundPage;


### PR DESCRIPTION
## Summary
- fix python syntax error in test placeholder
- add a simple CodeSandbox playground page
- document the new developer portal playground

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68806afaf5e0832086206b1b03ed3aa7