### PR TITLE
Add React Native wallet app with biometric unlock

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,68 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import * as LocalAuthentication from 'expo-local-authentication';
+
+export default function App() {
+  const [isBiometricSupported, setIsBiometricSupported] = useState(false);
+  const [authenticated, setAuthenticated] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    LocalAuthentication.hasHardwareAsync().then(setIsBiometricSupported);
+  }, []);
+
+  const handleAuth = useCallback(async () => {
+    try {
+      const result = await LocalAuthentication.authenticateAsync({
+        promptMessage: 'Unlock Wallet',
+        fallbackLabel: 'Use Passcode',
+        disableDeviceFallback: false
+      });
+      if (result.success) {
+        setAuthenticated(true);
+        setErrorMessage('');
+      } else {
+        setErrorMessage(result.error || 'Authentication failed');
+      }
+    } catch (err: any) {
+      setErrorMessage(err.message);
+    }
+  }, []);
+
+  if (!authenticated) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Chai Wallet</Text>
+        {isBiometricSupported ? (
+          <Button title="Unlock with Biometrics" onPress={handleAuth} />
+        ) : (
+          <Text>Biometric authentication not available</Text>
+        )}
+        {errorMessage ? <Text style={styles.error}>{errorMessage}</Text> : null}
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Wallet unlocked!</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 16
+  },
+  error: {
+    marginTop: 16,
+    color: 'red'
+  }
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,28 @@
+# Chai Wallet Mobile App
+
+This React Native application demonstrates a mobile-first wallet that can be unlocked using the device's biometric sensors (Face ID, Touch ID, etc.). It is built with Expo for ease of development.
+
+## Setup
+
+1. Install Node.js and `npm` if you haven't already.
+2. Install the Expo CLI globally:
+   ```bash
+   npm install -g expo-cli
+   ```
+3. Install dependencies:
+   ```bash
+   cd mobile
+   npm install
+   ```
+4. Run the application:
+   ```bash
+   npm start
+   ```
+   This will open the Expo developer tools. You can then launch the app on an emulator or a physical device.
+
+## Features
+
+- Prompts the user for biometric authentication on startup.
+- Displays a simple confirmation once the wallet is unlocked.
+
+This is a minimal example meant to showcase biometric wallet unlocking. Integrate your wallet logic where the `Wallet unlocked!` message is displayed.

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "chai-wallet-app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^48.0.0",
+    "expo-local-authentication": "^13.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.0"
+  }
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "expo/tsconfig.base"
+}


### PR DESCRIPTION
## Summary
- add a new `mobile` directory containing a simple React Native wallet application
- implement biometric unlocking via `expo-local-authentication`
- document how to run the mobile app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68806adfc1388320953b0817e388d298