### PR TITLE
Add Express backend with GraphQL/webhook support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+backend/node_modules/
+backend/dist/
+backend/package-lock.json
+backend/__tests__/*.js

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Backend APIs
+
+A lightweight Express server provides REST and GraphQL endpoints with webhook handlers for Workday and SAP integrations.
+
+### Run in development
+
+```bash
+cd backend
+npm install
+npm run dev
+```
+
+The server exposes the following routes:
+
+- `POST /webhook/workday` – Webhook receiver for Workday events.
+- `POST /webhook/sap` – Webhook receiver for SAP events.
+- `GET /graphql` – GraphQL endpoint with a simple `status` query.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "chai-vc-backend",
+  "version": "0.1.0",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "ts-node src/server.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-graphql": "^0.12.0",
+    "graphql": "^15.8.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.3",
+    "@types/node": "^24.0.14",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,47 @@
+import express from 'express';
+import { buildSchema } from 'graphql';
+import { graphqlHTTP } from 'express-graphql';
+
+// Basic GraphQL schema and resolver
+const schema = buildSchema(`
+  type Query {
+    status: String
+  }
+`);
+
+const root = {
+  status: () => 'ok',
+};
+
+const app = express();
+app.use(express.json());
+
+// GraphQL endpoint
+app.use('/graphql', graphqlHTTP({
+  schema,
+  rootValue: root,
+  graphiql: true,
+}));
+
+// REST webhook endpoints
+app.post('/webhook/workday', (req, res) => {
+  console.log('Received Workday webhook:', req.body);
+  // handle Workday payload
+  res.status(200).json({ message: 'Workday webhook received' });
+});
+
+app.post('/webhook/sap', (req, res) => {
+  console.log('Received SAP webhook:', req.body);
+  // handle SAP payload
+  res.status(200).json({ message: 'SAP webhook received' });
+});
+
+// Health check
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'running' });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "noImplicitAny": false
+  },
+  "exclude": [
+    "__tests__"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Express/GraphQL server with Workday & SAP webhook handlers
- document API usage in README
- configure TypeScript build and ignore temporary files

## Testing
- `npm install`
- `npm run build`
- `npm run dev --silent & sleep 3; pkill node`

------
https://chatgpt.com/codex/tasks/task_e_68768fd8d4508320a04f82864fdc306b