### PR TITLE
Add DIDComm messaging prototype

### DIFF
--- a/didcomm_messaging/README.md
+++ b/didcomm_messaging/README.md
@@ -1,0 +1,3 @@
+# DIDComm Messaging Prototype
+
+This folder contains a minimal prototype demonstrating inter-wallet DIDComm-style messaging using HTTP. Run `prototype_server.py` to start a local server and use `wallet_client.py` to send or receive messages.

--- a/didcomm_messaging/prototype_server.py
+++ b/didcomm_messaging/prototype_server.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Simple DIDComm prototype server for inter-wallet messaging."""
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+
+# In-memory message store: {recipient_id: [messages]}
+MESSAGE_STORE = {}
+
+class DIDCommHandler(BaseHTTPRequestHandler):
+    def _set_headers(self, status=200, content_type="application/json"):
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.end_headers()
+
+    def do_POST(self):
+        if self.path == "/send":
+            length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(length)
+            try:
+                data = json.loads(body)
+                sender = data.get("from")
+                recipient = data.get("to")
+                msg_type = data.get("type", "message")
+                content = data.get("body")
+                if not sender or not recipient or content is None:
+                    raise ValueError("'from', 'to' and 'body' are required")
+                message = {
+                    "from": sender,
+                    "to": recipient,
+                    "type": msg_type,
+                    "body": content,
+                }
+                MESSAGE_STORE.setdefault(recipient, []).append(message)
+                self._set_headers(200)
+                self.wfile.write(json.dumps({"status": "stored"}).encode())
+            except (json.JSONDecodeError, ValueError) as e:
+                self._set_headers(400)
+                self.wfile.write(json.dumps({"error": str(e)}).encode())
+        else:
+            self._set_headers(404)
+            self.wfile.write(b"{}")
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/messages":
+            query = parse_qs(parsed.query)
+            wallet_id = query.get("wallet_id", [None])[0]
+            if not wallet_id:
+                self._set_headers(400)
+                self.wfile.write(json.dumps({"error": "wallet_id query param required"}).encode())
+                return
+            messages = MESSAGE_STORE.pop(wallet_id, [])
+            self._set_headers(200)
+            self.wfile.write(json.dumps({"messages": messages}).encode())
+        else:
+            self._set_headers(404)
+            self.wfile.write(b"{}")
+
+
+def run(host="0.0.0.0", port=8000):
+    server = HTTPServer((host, port), DIDCommHandler)
+    print(f"DIDComm prototype server running on {host}:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    run()

--- a/didcomm_messaging/wallet_client.py
+++ b/didcomm_messaging/wallet_client.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""CLI client for DIDComm prototype server."""
+
+import argparse
+import json
+from urllib import request, parse
+
+
+def send_message(server_url: str, sender: str, recipient: str, body: str, msg_type: str = "message"):
+    data = json.dumps({
+        "from": sender,
+        "to": recipient,
+        "type": msg_type,
+        "body": body,
+    }).encode()
+    req = request.Request(parse.urljoin(server_url, "/send"), data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+    with request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def fetch_messages(server_url: str, wallet_id: str):
+    url = parse.urljoin(server_url, f"/messages?wallet_id={parse.quote(wallet_id)}")
+    with request.urlopen(url) as resp:
+        return json.loads(resp.read())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="DIDComm wallet client")
+    parser.add_argument("server", help="Base URL of DIDComm server, e.g. http://localhost:8000")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    send_p = subparsers.add_parser("send", help="Send a message")
+    send_p.add_argument("sender")
+    send_p.add_argument("recipient")
+    send_p.add_argument("body")
+    send_p.add_argument("--type", default="message")
+
+    recv_p = subparsers.add_parser("recv", help="Fetch messages for wallet")
+    recv_p.add_argument("wallet_id")
+
+    args = parser.parse_args()
+
+    if args.command == "send":
+        result = send_message(args.server, args.sender, args.recipient, args.body, args.type)
+        print(json.dumps(result, indent=2))
+    elif args.command == "recv":
+        result = fetch_messages(args.server, args.wallet_id)
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple DIDComm-style prototype using HTTP
- provide wallet client script for sending and receiving messages
- document prototype usage

## Testing
- `python3 didcomm_messaging/prototype_server.py &`
- `python3 didcomm_messaging/wallet_client.py http://localhost:8000 send alice bob "Hello" --type greeting`
- `python3 didcomm_messaging/wallet_client.py http://localhost:8000 recv bob`

------
https://chatgpt.com/codex/tasks/task_e_68768fe1a8c48320b74cbbe7fccbaf26