### PR TITLE
Add credential validation tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+See `docs/credential_validation.md` for developer tutorials on credential validation.

--- a/docs/credential_validation.md
+++ b/docs/credential_validation.md
@@ -1,0 +1,84 @@
+# Credential Validation Tutorials
+
+This document shows example workflows for validating digital credentials in different languages.
+
+## Solidity
+
+The repository does not include on-chain credential code yet, but you can deploy a Solidity contract that checks a credential's issuer address and signature. Example snippet:
+
+```solidity
+pragma solidity ^0.8.0;
+
+contract CredentialVerifier {
+    address public trustedIssuer;
+
+    constructor(address _issuer) {
+        trustedIssuer = _issuer;
+    }
+
+    function validate(bytes32 credentialHash, bytes memory signature) public view returns (bool) {
+        bytes32 prefixedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", credentialHash));
+        return trustedIssuer == recoverSigner(prefixedHash, signature);
+    }
+
+    function recoverSigner(bytes32 message, bytes memory sig) internal pure returns (address) {
+        (uint8 v, bytes32 r, bytes32 s) = splitSignature(sig);
+        return ecrecover(message, v, r, s);
+    }
+
+    function splitSignature(bytes memory sig) internal pure returns (uint8, bytes32, bytes32) {
+        require(sig.length == 65, "invalid signature length");
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := mload(add(sig, 32))
+            s := mload(add(sig, 64))
+            v := byte(0, mload(add(sig, 96)))
+        }
+        return (v, r, s);
+    }
+}
+```
+
+## Rust
+
+The `backend/src/blockchain/polkadot_service.ts` file is a placeholder for integrating with Polkadot.
+To validate credentials using Rust, you could create a Substrate pallet that verifies a signature against stored issuer keys.
+
+```rust
+use sp_io::crypto::sr25519_verify;
+use sp_core::sr25519;
+
+pub fn validate(credential_hash: &[u8; 32], signature: &sr25519::Signature, issuer: &sr25519::Public) -> bool {
+    sr25519_verify(signature, credential_hash, issuer)
+}
+```
+
+Compile the pallet as part of your runtime and call `validate` when processing a transaction that references a credential.
+
+## JavaScript/TypeScript
+
+The backend controller at `backend/src/controllers/credential_controller.ts` is currently just a stub:
+
+```typescript
+// credential_controller.ts - placeholder or stub for chai-vc-platform
+```
+
+To validate credentials in Node.js, you could add code that verifies a JSON Web Token (JWT) or checks an Ethereum signature:
+
+```typescript
+import { ethers } from 'ethers';
+
+export function validateCredential(credentialHash: string, signature: string, issuer: string): boolean {
+    const messageHash = ethers.utils.hashMessage(credentialHash);
+    const signer = ethers.utils.verifyMessage(ethers.utils.arrayify(messageHash), signature);
+    return signer.toLowerCase() === issuer.toLowerCase();
+}
+```
+
+Call this function inside your API routes or GraphQL resolvers when a credential is submitted.
+
+---
+
+These examples show how you might implement credential validation in different languages. The repository currently contains only stubs, so you would integrate these snippets into the appropriate locations when implementing real credential flows.


### PR DESCRIPTION
## Summary
- add credential validation docs for Solidity, Rust, and JS
- link the new tutorial from the README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687691f4adc08320b7c816581646d809