### PR TITLE
Add career insights service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Career Insights Service
+
+The `career-insights-service` folder provides a small Python module that
+recommends upskilling paths for different job roles. Run it from the command
+line and pass a role name along with any existing skills to receive AI-inspired
+career advice.

--- a/career-insights-service/src/insights.py
+++ b/career-insights-service/src/insights.py
@@ -1,0 +1,71 @@
+ROLE_SKILL_MAP = {
+    "data scientist": [
+        "Advanced machine learning",
+        "Cloud data pipelines",
+        "Big data tools",
+    ],
+    "software engineer": [
+        "Cloud infrastructure",
+        "System design patterns",
+        "DevOps automation",
+    ],
+    "nurse": [
+        "Digital health records",
+        "Telehealth coordination",
+        "Clinical informatics",
+    ],
+    "product manager": [
+        "AI product strategy",
+        "Data-driven decision making",
+        "Agile frameworks",
+    ],
+}
+
+
+def recommend_upskilling(role: str, skills=None):
+    """Return recommended upskilling paths for a given role and current skills."""
+    role_normalized = role.lower()
+    skills = skills or []
+    recommended = []
+
+    for key, recs in ROLE_SKILL_MAP.items():
+        if key in role_normalized:
+            recommended = recs
+            break
+    else:
+        recommended = [
+            "AI fundamentals",
+            "Data analytics",
+            "Cloud basics",
+        ]
+
+    # Determine which recommendations the user is missing
+    missing = [
+        r for r in recommended if r.lower() not in {s.lower() for s in skills}
+    ]
+
+    return {
+        "role": role,
+        "recommended_skills": recommended,
+        "missing_skills": missing,
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(description="Career insights recommender")
+    parser.add_argument("role", help="Target job role")
+    parser.add_argument(
+        "--skills",
+        help="Comma separated list of existing skills",
+        default="",
+    )
+
+    args = parser.parse_args()
+    current_skills = [s.strip() for s in args.skills.split(",") if s.strip()]
+
+    insights = recommend_upskilling(args.role, current_skills)
+    print(json.dumps(insights, indent=2))
+


### PR DESCRIPTION
## Summary
- add `career-insights-service` with an `insights.py` module to recommend upskilling paths for different job roles
- document the new service in the project README

## Testing
- `python3 career-insights-service/src/insights.py "Software Engineer" --skills python,git`
- `python3 career-insights-service/src/insights.py "Data Scientist" --skills "Python, SQL"`


------
https://chatgpt.com/codex/tasks/task_e_68769230737c832096cf35a3aad8d4e3