### PR TITLE
Add staffing DAO integration prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Staffing DAO Integration
+
+Prototype modules exist in the backend to interface with a decentralized staffing DAO for gig placements. See `backend/src/blockchain/staffing_dao_integration.js` for details.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/backend/__tests__/staffing_dao_integration.test.js
+++ b/backend/__tests__/staffing_dao_integration.test.js
@@ -1,0 +1,11 @@
+const { StaffingDAOIntegration } = require('../src/blockchain/staffing_dao_integration.js');
+
+(async () => {
+  const dao = new StaffingDAOIntegration();
+  const gigs = await dao.fetchGigs();
+  if (!Array.isArray(gigs)) throw new Error('fetchGigs should return an array');
+  const tx = await dao.postGig({ id: '2', description: 'Test gig', reward: '5 USDC' });
+  if (typeof tx !== 'string') throw new Error('postGig should return a tx id');
+  const accepted = await dao.acceptGig('2');
+  if (accepted !== true) throw new Error('acceptGig should return true');
+})();

--- a/backend/src/blockchain/staffing_dao_integration.js
+++ b/backend/src/blockchain/staffing_dao_integration.js
@@ -1,0 +1,44 @@
+/**
+ * Prototype integration layer for a decentralized staffing DAO.
+ * This module provides simple placeholders for posting gigs, fetching listings
+ * and accepting work. In a real system these would interact with on-chain
+ * contracts or decentralized storage.
+ */
+
+class StaffingDAOIntegration {
+  /**
+   * Post a new gig to the DAO.
+   * @param {Object} gig
+   * @param {string} gig.id
+   * @param {string} gig.description
+   * @param {string} gig.reward
+   * @returns {Promise<string>} transaction id placeholder
+   */
+  async postGig(gig) {
+    console.log('Posting gig', gig);
+    return Promise.resolve('tx-placeholder');
+  }
+
+  /**
+   * Fetch open gigs from the DAO.
+   * @returns {Promise<Array>}
+   */
+  async fetchGigs() {
+    console.log('Fetching gigs');
+    return Promise.resolve([
+      { id: '1', description: 'Sample gig from DAO', reward: '10 USDC' }
+    ]);
+  }
+
+  /**
+   * Accept a gig placement.
+   * @param {string} gigId
+   * @returns {Promise<boolean>}
+   */
+  async acceptGig(gigId) {
+    console.log('Accepting gig', gigId);
+    return Promise.resolve(true);
+  }
+}
+
+module.exports = { StaffingDAOIntegration };

--- a/backend/src/controllers/gig_controller.js
+++ b/backend/src/controllers/gig_controller.js
@@ -1,0 +1,17 @@
+const { StaffingDAOIntegration } = require('../blockchain/staffing_dao_integration');
+
+const dao = new StaffingDAOIntegration();
+
+async function createGig(gig) {
+  return dao.postGig(gig);
+}
+
+async function listGigs() {
+  return dao.fetchGigs();
+}
+
+async function takeGig(gigId) {
+  return dao.acceptGig(gigId);
+}
+
+module.exports = { createGig, listGigs, takeGig };


### PR DESCRIPTION
## Summary
- add a basic `StaffingDAOIntegration` module for gig posting
- create a simple controller for gig operations
- add a minimal test invoking the new integration
- clean up placeholder python test
- document the new integration in README

## Testing
- `pytest -q`
- `node backend/__tests__/staffing_dao_integration.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68769241efc483209399927a5d47ed39