### PR TITLE
Add referee endorsement attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Trusted Referee Endorsements
+
+The backend now includes a stub `RefereeAttestationService` which simulates
+recording referee endorsements on-chain. See
+`backend/src/blockchain/referee_attestation.ts` for details.

--- a/backend/__tests__/referee_attestation.test.ts
+++ b/backend/__tests__/referee_attestation.test.ts
@@ -1,0 +1,14 @@
+import { BlockchainIntegration } from '../src/blockchain/blockchain_integration';
+
+const blockchain = new BlockchainIntegration();
+
+describe('referee endorsement attestation', () => {
+  it('creates a mock attestation hash', async () => {
+    const id = await blockchain.recordRefereeEndorsement({
+      credentialId: 'cred-1',
+      refereeDid: 'did:example:referee',
+      message: 'verified',
+    });
+    expect(id).toMatch(/^attest-/);
+  });
+});

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,15 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { RefereeEndorsement, RefereeAttestationService } from './referee_attestation';
+
+export class BlockchainIntegration {
+  private refereeService = new RefereeAttestationService();
+
+  /**
+   * Record a referee's endorsement as an on-chain attestation.
+   * Returns the transaction or attestation identifier.
+   */
+  async recordRefereeEndorsement(endorsement: RefereeEndorsement): Promise<string> {
+    // In a real system additional logic would be added here to
+    // interface with the chosen blockchain network.
+    return this.refereeService.endorse(endorsement);
+  }
+}

--- a/backend/src/blockchain/referee_attestation.ts
+++ b/backend/src/blockchain/referee_attestation.ts
@@ -1,0 +1,19 @@
+export interface RefereeEndorsement {
+  credentialId: string;
+  refereeDid: string;
+  message: string;
+}
+
+export class RefereeAttestationService {
+  /**
+   * Create an on-chain attestation for a referee endorsement.
+   * In a real implementation this would publish a transaction to a
+   * blockchain network. Here we simulate by returning a mock hash.
+   */
+  async endorse(data: RefereeEndorsement): Promise<string> {
+    const concatenated = `${data.credentialId}-${data.refereeDid}-${data.message}`;
+    const mockHash = 'attest-' + Buffer.from(concatenated).toString('hex').slice(0, 16);
+    // Placeholder for on-chain call
+    return mockHash;
+  }
+}


### PR DESCRIPTION
## Summary
- support trusted referee endorsements using a `RefereeAttestationService`
- expose the functionality via `BlockchainIntegration`
- add a minimal test harness for the new feature
- document the addition in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687692590ec08320b0c7fdf5af3fc7ba