### PR TITLE
Add employment offer generator and escrow

### DIFF
--- a/backend/__tests__/employment_offer.test.js
+++ b/backend/__tests__/employment_offer.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { generateEmploymentOffer } = require('../src/employment/offer_generator');
+const { EscrowService } = require('../src/employment/escrow_service');
+
+const offer = generateEmploymentOffer({
+  employeeName: 'Alice',
+  employerName: 'Acme Corp',
+  role: 'Engineer',
+  salary: '$100k',
+  depositEther: 1
+});
+
+assert.strictEqual(offer.employeeName, 'Alice');
+assert.ok(offer.agreement.includes('Acme Corp'));
+
+const escrow = new EscrowService();
+escrow.createEscrow('offer1', 1);
+assert.strictEqual(escrow.getEscrow('offer1').amount, 1);
+escrow.releaseEscrow('offer1');
+assert.ok(escrow.getEscrow('offer1').released);
+
+console.log('Employment offer tests passed');

--- a/backend/src/employment/escrow_service.js
+++ b/backend/src/employment/escrow_service.js
@@ -1,0 +1,31 @@
+/**
+ * Simple in-memory escrow service to emulate on-chain escrow functionality.
+ */
+class EscrowService {
+  constructor() {
+    this.deposits = new Map();
+  }
+
+  createEscrow(offerId, amount) {
+    if (this.deposits.has(offerId)) {
+      throw new Error('Escrow already exists for offer');
+    }
+    this.deposits.set(offerId, { amount, released: false });
+  }
+
+  releaseEscrow(offerId) {
+    const escrow = this.deposits.get(offerId);
+    if (!escrow) {
+      throw new Error('Escrow not found');
+    }
+    if (escrow.released) {
+      throw new Error('Escrow already released');
+    }
+    escrow.released = true;
+  }
+
+  getEscrow(offerId) {
+    return this.deposits.get(offerId);
+  }
+}
+module.exports = { EscrowService };

--- a/backend/src/employment/offer_generator.js
+++ b/backend/src/employment/offer_generator.js
@@ -1,0 +1,17 @@
+/**
+ * Utility to generate an employment offer agreement with optional escrow deposit.
+ * Returns a JSON representation of the agreement.
+ */
+function generateEmploymentOffer({ employeeName, employerName, role, salary, depositEther }) {
+  const date = new Date().toISOString().split('T')[0];
+  return {
+    employeeName,
+    employerName,
+    role,
+    salary,
+    depositEther,
+    date,
+    agreement: `This offer is made to ${employeeName} for the role of ${role} at ${employerName}. Salary is ${salary}.`
+  };
+}
+module.exports = { generateEmploymentOffer };


### PR DESCRIPTION
## Summary
- add employment offer generator module
- add simple in-memory escrow service
- add tests verifying generator and escrow workflow

## Testing
- `node backend/__tests__/employment_offer.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68769221334883208f454e3e36e13822