### PR TITLE
Implement talent scout notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Talent Scouting Notifications
+
+The backend now includes a `TalentScoutNotifier` service that allows recruiters to register interest in specific credentials for a given location. Whenever a new candidate with matching credentials is added, registered watchers receive a notification such as **"New certified X in your area"**.
+
+The notifier is defined in `backend/src/notifications/talent_scout_notifier.ts` and exposes methods to add or remove watchers and send notifications for new credentials.

--- a/backend/src/notifications/talent_scout_notifier.ts
+++ b/backend/src/notifications/talent_scout_notifier.ts
@@ -1,0 +1,50 @@
+export interface Candidate {
+  id: string;
+  name: string;
+  credentials: string[];
+  location: string;
+}
+
+export interface Watcher {
+  id: string;
+  credential: string;
+  location: string;
+  notify: (message: string) => void;
+}
+
+/**
+ * TalentScoutNotifier stores watchers interested in certain credentials and
+ * notifies them when a new matching candidate is registered.
+ */
+export class TalentScoutNotifier {
+  private watchers: Map<string, Watcher> = new Map();
+
+  /**
+   * Register a watcher interested in a specific credential and location.
+   */
+  addWatcher(watcher: Watcher): void {
+    this.watchers.set(watcher.id, watcher);
+  }
+
+  /**
+   * Remove a previously registered watcher.
+   */
+  removeWatcher(id: string): void {
+    this.watchers.delete(id);
+  }
+
+  /**
+   * Notify watchers about a newly certified candidate.
+   */
+  notifyNewCredential(candidate: Candidate): void {
+    for (const watcher of this.watchers.values()) {
+      const matchesCredential = candidate.credentials.includes(watcher.credential);
+      const matchesLocation = candidate.location.toLowerCase() === watcher.location.toLowerCase();
+
+      if (matchesCredential && matchesLocation) {
+        const message = `New certified ${watcher.credential} in your area: ${candidate.name}`;
+        watcher.notify(message);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a service for AI-driven talent scout notifications
- document the new notifier in the README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68769269e7bc8320a0f95f10314f543e