### PR TITLE
Add Circom ZK circuit for credential attribute proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## ZK Circuits
+
+Circuits under `zk-circuits/` provide zero-knowledge proofs of credential
+attributes without revealing the entire credential. The `credentialAttributeEquality.circom`
+circuit proves that a specific attribute equals an expected value while
+ensuring the Poseidon commitment of all attributes remains intact.
+
+To compile:
+
+```bash
+circom zk-circuits/credentialAttributeEquality.circom --r1cs --wasm -o build
+```
+
+This will create the R1CS and WASM files in the `build/` directory.

--- a/zk-circuits/credentialAttributeEquality.circom
+++ b/zk-circuits/credentialAttributeEquality.circom
@@ -1,0 +1,30 @@
+include "circomlib/poseidon.circom";
+
+// CredentialAttributeEquality checks that the Poseidon hash of all
+// credential attributes matches the provided commitment and that the
+// attribute at a fixed index equals the expected value without revealing
+// other attributes.
+
+template CredentialAttributeEquality(N, IDX) {
+    // Private credential attributes
+    signal input attrs[N];
+
+    // Public Poseidon commitment to all attributes
+    signal input commitment;
+
+    // Public value that the attribute at IDX must equal
+    signal input expected;
+
+    // Recompute Poseidon hash and enforce it matches the commitment
+    component hash = Poseidon(N);
+    for (var i = 0; i < N; i++) {
+        hash.inputs[i] <== attrs[i];
+    }
+    hash.out === commitment;
+
+    // Prove that the attribute at index IDX equals the expected value
+    attrs[IDX] === expected;
+}
+
+// Default circuit instance: four attributes, proving the first attribute
+component main = CredentialAttributeEquality(4, 0);


### PR DESCRIPTION
## Summary
- create `credentialAttributeEquality.circom` circuit for verifying an attribute commitment
- document ZK circuits and compilation instructions in the README

## Testing
- `npm test --silent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688069d7ebd483208079bc153491987b