### PR TITLE
Add revocation watcher service

### DIFF
--- a/backend/src/watchers/index.ts
+++ b/backend/src/watchers/index.ts
@@ -1,0 +1,18 @@
+import { RevocationWatcher } from './revocation_watcher';
+
+const endpointsEnv = process.env.REVOCATION_ENDPOINTS || '';
+const endpoints = endpointsEnv.split(',').map(e => e.trim()).filter(e => e);
+
+if (endpoints.length === 0) {
+  console.error('No revocation endpoints configured. Set REVOCATION_ENDPOINTS env variable.');
+  process.exit(1);
+}
+
+const watcher = new RevocationWatcher({ endpoints, pollingIntervalMs: 5000 });
+
+watcher.on('revoked', id => {
+  console.log(`Credential revoked: ${id}`);
+  // Integration point: connect to credential service or database here.
+});
+
+watcher.start();

--- a/backend/src/watchers/revocation_watcher.ts
+++ b/backend/src/watchers/revocation_watcher.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from 'events';
+
+export interface RevocationWatcherOptions {
+  endpoints: string[];
+  pollingIntervalMs?: number;
+}
+
+/**
+ * RevocationWatcher polls off-chain endpoints for lists of revoked credential IDs.
+ * When a new revocation is discovered, a `revoked` event is emitted with the credential ID.
+ */
+export class RevocationWatcher extends EventEmitter {
+  private seenRevocations: Set<string> = new Set();
+  private timer?: NodeJS.Timeout;
+  private endpoints: string[];
+  private interval: number;
+
+  constructor(options: RevocationWatcherOptions) {
+    super();
+    this.endpoints = options.endpoints;
+    this.interval = options.pollingIntervalMs ?? 10000;
+  }
+
+  /** Start polling the endpoints. */
+  start() {
+    this.stop();
+    this.timer = setInterval(() => this.poll(), this.interval);
+    this.poll().catch(err => console.error('revocation watcher poll error', err));
+  }
+
+  /** Stop polling the endpoints. */
+  stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private async poll() {
+    for (const url of this.endpoints) {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          console.error(`failed to fetch ${url}: ${response.status} ${response.statusText}`);
+          continue;
+        }
+        const data = await response.json();
+        const revokedIds: string[] = Array.isArray((data as any).revokedCredentialIds)
+          ? (data as any).revokedCredentialIds
+          : [];
+        for (const id of revokedIds) {
+          if (!this.seenRevocations.has(id)) {
+            this.seenRevocations.add(id);
+            this.emit('revoked', id);
+          }
+        }
+      } catch (err) {
+        console.error(`error fetching ${url}`, err);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement revocation watcher that polls off-chain endpoints for revoked credential ids
- add startup script for revocation watcher

## Testing
- `pytest` *(fails: SyntaxError in placeholder test)*
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688069f80d30832095f486d0ff686e0e