### PR TITLE
Implement on-chain logging placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Blockchain Logging
+
+The backend includes a simple `BlockchainIntegration` utility which allows
+appending immutable decision logs to a mocked Polkadot service. These logs
+capture both AI and human-driven decisions and serve as placeholders for future
+on-chain implementations.

--- a/backend/__tests__/blockchain_logging.test.ts
+++ b/backend/__tests__/blockchain_logging.test.ts
@@ -1,0 +1,12 @@
+import { BlockchainIntegration } from '../src/blockchain/blockchain_integration';
+
+(async () => {
+  const blockchain = new BlockchainIntegration();
+  await blockchain.logDecision('approve credential', { id: 1 });
+  await blockchain.logDecision('reject credential', { id: 2 });
+  const logs = (blockchain as any).service.getLogs();
+  if (logs.length !== 2) {
+    throw new Error('Incorrect number of log entries');
+  }
+  console.log('blockchain logging test passed');
+})();

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,26 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { PolkadotService } from './polkadot_service';
+
+export interface DecisionMetadata {
+  [key: string]: any;
+}
+
+export class BlockchainIntegration {
+  private service: PolkadotService;
+
+  constructor(service = new PolkadotService()) {
+    this.service = service;
+  }
+
+  /**
+   * Log a human or AI driven decision to the blockchain.
+   * The log entry is immutable once appended to the chain.
+   */
+  async logDecision(decision: string, metadata: DecisionMetadata = {}): Promise<void> {
+    const entry = {
+      decision,
+      metadata,
+      timestamp: new Date().toISOString(),
+    };
+    await this.service.appendLog(JSON.stringify(entry));
+  }
+}

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,25 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+/**
+ * Simple in-memory representation of a Polkadot service. In the real
+ * implementation this would interact with the blockchain. Here we only
+ * emulate append-only behaviour for testing.
+ */
+export class PolkadotService {
+  private logs: string[] = [];
+
+  /**
+   * Append an immutable log entry to the on-chain log.
+   */
+  async appendLog(entry: string): Promise<void> {
+    // In a real environment this would submit a transaction.
+    this.logs.push(entry);
+  }
+
+  /**
+   * Retrieve all log entries.
+   */
+  getLogs(): string[] {
+    // Return a copy to enforce immutability from the outside.
+    return [...this.logs];
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement `BlockchainIntegration.logDecision` for immutable logging
- add an in-memory `PolkadotService` to hold log entries
- document blockchain logging capability in README
- add a simple test script

## Testing
- `npx tsc backend/__tests__/blockchain_logging.test.ts backend/src/blockchain/blockchain_integration.ts backend/src/blockchain/polkadot_service.ts --module commonjs --lib ES2020,DOM --outDir backend/__tests__/dist`
- `node backend/__tests__/dist/__tests__/blockchain_logging.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68806aa59b6883208913cee68b2a7fae