### PR TITLE
Add Express entry point

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+import { graphqlHTTP } from 'express-graphql';
+import { schema, rootValue } from './graphql/graphql_api_scaffold';
+
+const app = express();
+
+// Parse JSON request bodies
+app.use(express.json());
+
+// Mount the GraphQL endpoint
+app.use('/graphql', graphqlHTTP({
+  schema,
+  rootValue,
+  graphiql: true,
+}));
+
+export default app;
+
+// If this module is executed directly, start the server
+if (require.main === module) {
+  const port = process.env.PORT || 4000;
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}


### PR DESCRIPTION
## Summary
- create an Express server in `backend/src/index.ts`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6882c81e6ea48320a6e3bfc7f4c66fec