### PR TITLE
Add GraphQL type definitions

### DIFF
--- a/backend/src/graphql/graphql_api_scaffold.ts
+++ b/backend/src/graphql/graphql_api_scaffold.ts
@@ -1,1 +1,49 @@
-// graphql_api_scaffold.ts - placeholder or stub for chai-vc-platform
+// Basic GraphQL schema for chai-vc-platform API
+export const typeDefs = /* GraphQL */ `
+  type User {
+    id: ID!
+    name: String!
+    email: String!
+    credentials: [Credential!]
+    jobs: [Job!]
+  }
+
+  type Credential {
+    id: ID!
+    name: String!
+    issuer: String!
+    issuedAt: String
+    expiresAt: String
+    user: User
+  }
+
+  type Job {
+    id: ID!
+    title: String!
+    description: String
+    postedBy: User
+    applicants: [User!]
+  }
+
+  type Query {
+    users: [User!]
+    user(id: ID!): User
+    credentials: [Credential!]
+    credential(id: ID!): Credential
+    jobs: [Job!]
+    job(id: ID!): Job
+  }
+
+  type Mutation {
+    createUser(name: String!, email: String!): User
+    issueCredential(
+      userId: ID!
+      name: String!
+      issuer: String!
+      issuedAt: String
+      expiresAt: String
+    ): Credential
+    postJob(title: String!, description: String, postedBy: ID!): Job
+    applyForJob(jobId: ID!, userId: ID!): Job
+  }
+`;


### PR DESCRIPTION
## Summary
- add GraphQL schema for backend

## Testing
- `pytest` *(fails: SyntaxError in ai-matcher-service/tests/test_matcher.py)*

------
https://chatgpt.com/codex/tasks/task_e_6882c83adaf0832090813f46559a3e05