### PR TITLE
Implement GDPR erasure workflow stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## GDPR/CCPA Right-to-Erasure
+
+The backend includes a stubbed workflow for processing data erasure requests.
+Sensitive user data is hashed and the resulting digest is stored on-chain using
+`PolkadotService` for auditability.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,4 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# Placeholder tests for ai-matcher-service
+
+def test_placeholder():
+    assert True

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,16 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+export interface ErasureRecord {
+  userId: string;
+  dataHash: string;
+  timestamp: number;
+}
+
+export class PolkadotService {
+  /**
+   * Persist an anonymized erasure record to the blockchain.
+   * The implementation is a stub for demonstration purposes.
+   */
+  async recordErasure(record: ErasureRecord): Promise<void> {
+    // In a real implementation, this would submit a transaction to the chain.
+    console.log('Recording erasure on-chain:', record);
+  }
+}

--- a/backend/src/blockchain/right_to_erasure.ts
+++ b/backend/src/blockchain/right_to_erasure.ts
@@ -1,0 +1,23 @@
+import crypto from 'crypto';
+import { PolkadotService } from './polkadot_service';
+
+export interface ErasureRecord {
+  userId: string;
+  dataHash: string;
+  timestamp: number;
+}
+
+export class RightToErasure {
+  constructor(private polkadot: PolkadotService) {}
+
+  /**
+   * Anonymize sensitive data and record a proof on-chain.
+   * This implements a basic right-to-erasure workflow.
+   */
+  async processRequest(userId: string, personalData: string): Promise<ErasureRecord> {
+    const dataHash = crypto.createHash('sha256').update(personalData).digest('hex');
+    const record: ErasureRecord = { userId, dataHash, timestamp: Date.now() };
+    await this.polkadot.recordErasure(record);
+    return record;
+  }
+}


### PR DESCRIPTION
## Summary
- add simple right-to-erasure implementation
- stub PolkadotService to accept erasure records
- add placeholder unit test
- mention erasure workflow in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68806a515cb88320ae99ae2f52293f63