### PR TITLE
Add mTLS and OPA policy integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Security
+
+All service-to-service communication now uses **mTLS**. Certificates are mounted
+from Kubernetes secrets and referenced by the applications. An **OPA** sidecar
+is injected into each deployment to enforce policies defined in `opa/policy.rego`.

--- a/ai-matcher-service/src/routes/match.py
+++ b/ai-matcher-service/src/routes/match.py
@@ -1,1 +1,43 @@
-// match.py - placeholder or stub for chai-vc-platform
+from fastapi import APIRouter, HTTPException, Request
+import os
+import requests
+
+router = APIRouter()
+
+OPA_URL = os.getenv("OPA_URL", "http://localhost:8181/v1/data/chai/authz/allow")
+BACKEND_URL = os.getenv("BACKEND_URL", "https://backend-service")
+CLIENT_CERT = os.getenv("CLIENT_CERT", "/certs/client.crt")
+CLIENT_KEY = os.getenv("CLIENT_KEY", "/certs/client.key")
+CA_CERT = os.getenv("CA_CERT", "/certs/ca.crt")
+
+@router.post("/match")
+async def match(request: Request):
+    # Call OPA to authorize this request
+    data = {
+        "input": {
+            "path": request.url.path,
+            "method": request.method,
+        }
+    }
+    try:
+        resp = requests.post(OPA_URL, json=data, timeout=2)
+        allowed = resp.json().get("result", False)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"OPA error: {exc}")
+
+    if not allowed:
+        raise HTTPException(status_code=403, detail="OPA policy denied the request")
+
+    # Example backend call secured with mTLS
+    try:
+        r = requests.get(
+            f"{BACKEND_URL}/health",
+            cert=(CLIENT_CERT, CLIENT_KEY),
+            verify=CA_CERT,
+            timeout=2,
+        )
+        backend_status = r.json()
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Backend call failed: {exc}")
+
+    return {"status": "ok", "backend": backend_status}

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,34 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+import importlib.util
+import pathlib
+spec = importlib.util.spec_from_file_location(
+    "match",
+    pathlib.Path(__file__).resolve().parents[1] / "src" / "routes" / "match.py",
+)
+match = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(match)
+router = match.router
+
+app = FastAPI()
+app.include_router(router)
+
+client = TestClient(app)
+
+
+def test_match_denied():
+    with patch('requests.post') as post:
+        post.return_value.json.return_value = {"result": False}
+        response = client.post('/match')
+        assert response.status_code == 403
+
+
+def test_match_allowed():
+    with patch('requests.post') as post, patch('requests.get') as get:
+        post.return_value.json.return_value = {"result": True}
+        get.return_value.json.return_value = {"ok": True}
+        response = client.post('/match')
+        assert response.status_code == 200
+        assert response.json()['backend'] == {"ok": True}

--- a/backend/__tests__/full_end_to_end_test.ts
+++ b/backend/__tests__/full_end_to_end_test.ts
@@ -1,1 +1,15 @@
-// full_end_to_end_test.ts - placeholder or stub for chai-vc-platform
+import { fetchMatching } from '../src/controllers/credential_controller';
+import nock from 'nock';
+
+test('fetchMatching allows when OPA permits', async () => {
+  nock('http://localhost:8181')
+    .post('/v1/data/chai/authz/allow')
+    .reply(200, { result: true });
+
+  nock('https://ai-matcher-service')
+    .get('/match')
+    .reply(200, { ok: true });
+
+  const result = await fetchMatching();
+  expect(result).toEqual({ ok: true });
+});

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,26 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import axios from 'axios';
+import fs from 'fs';
+import https from 'https';
+
+const httpsAgent = new https.Agent({
+  cert: fs.readFileSync(process.env.CLIENT_CERT || '/certs/client.crt'),
+  key: fs.readFileSync(process.env.CLIENT_KEY || '/certs/client.key'),
+  ca: fs.readFileSync(process.env.CA_CERT || '/certs/ca.crt'),
+  rejectUnauthorized: true,
+});
+
+const OPA_URL = process.env.OPA_URL || 'http://localhost:8181/v1/data/chai/authz/allow';
+
+export async function authorize(path: string, method: string): Promise<boolean> {
+  const resp = await axios.post(OPA_URL, { input: { path, method } });
+  return resp.data.result === true;
+}
+
+export async function fetchMatching(): Promise<any> {
+  const allowed = await authorize('/credentials', 'POST');
+  if (!allowed) {
+    throw new Error('OPA policy denied request');
+  }
+  const resp = await axios.get('https://ai-matcher-service/match', { httpsAgent });
+  return resp.data;
+}

--- a/k8s/ai-matcher-service.yaml
+++ b/k8s/ai-matcher-service.yaml
@@ -1,1 +1,28 @@
-// ai-matcher-service.yaml - placeholder or stub for chai-vc-platform
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-matcher-service
+  annotations:
+    openpolicyagent.org/inject: "yes"
+    sidecar.istio.io/inject: "true"
+spec:
+  selector:
+    matchLabels:
+      app: ai-matcher
+  template:
+    metadata:
+      labels:
+        app: ai-matcher
+    spec:
+      containers:
+        - name: matcher
+          image: matcher:latest
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+      volumes:
+        - name: certs
+          secret:
+            secretName: matcher-certs

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -1,1 +1,28 @@
-// backend-deployment.yaml - placeholder or stub for chai-vc-platform
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  annotations:
+    openpolicyagent.org/inject: "yes"
+    sidecar.istio.io/inject: "true"
+spec:
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: backend:latest
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+      volumes:
+        - name: certs
+          secret:
+            secretName: backend-certs

--- a/opa/policy.rego
+++ b/opa/policy.rego
@@ -1,0 +1,7 @@
+package chai.authz
+
+default allow = false
+
+allow {
+    input.method == "POST"
+}


### PR DESCRIPTION
## Summary
- secure Python matcher service with OPA checks and mTLS calls
- add tests for OPA authorization flow
- secure backend controller with OPA and mTLS
- define Kubernetes manifests with sidecar injection and cert mounts
- document mTLS and OPA policy enforcement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68806a67e6108320bdb06aa26a5bbe5d