### PR TITLE
Add SOC2 compliance dashboard workflow

### DIFF
--- a/.github/workflows/publish_soc2_dashboard.yml
+++ b/.github/workflows/publish_soc2_dashboard.yml
@@ -1,0 +1,28 @@
+name: Publish SOC2 Dashboard
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'compliance/**'
+      - '.github/workflows/publish_soc2_dashboard.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: './compliance'
+      - uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Compliance Dashboard
+
+SOC 2 compliance artifacts are published from the `compliance/` directory. A GitHub Actions workflow (`publish_soc2_dashboard.yml`) deploys the contents of this folder to GitHub Pages whenever updates are pushed to `main`.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,7 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+"""Basic placeholder tests for the ai-matcher-service."""
+
+
+def test_placeholder() -> None:
+    """Simple sanity check to ensure the test suite runs."""
+    assert True
+

--- a/compliance/README.md
+++ b/compliance/README.md
@@ -1,0 +1,5 @@
+# SOC 2 Compliance Dashboard
+
+This directory contains artifacts intended for public consumption regarding Chai VC Platform's SOC 2 compliance status.
+
+Add generated reports and dashboards here. The accompanying GitHub workflow publishes the contents of this folder to GitHub Pages as a simple DevOps dashboard.

--- a/compliance/index.html
+++ b/compliance/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Chai VC Platform - SOC 2 Compliance Dashboard</title>
+</head>
+<body>
+    <h1>SOC 2 Compliance Dashboard</h1>
+    <p>This page lists publicly available compliance artifacts.</p>
+    <ul>
+        <li><a href="README.md">Readme</a></li>
+        <!-- Add links to additional SOC 2 artifacts here -->
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a `compliance/` directory with a simple HTML dashboard and readme
- document the new SOC2 dashboard in the main README
- provide a GitHub Actions workflow to publish the dashboard to GitHub Pages
- fix placeholder test so pytest runs cleanly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68806a8d62ac83208085dde56fb063b2