### PR TITLE
Add cross-chain DID resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Cross-chain DID Resolution
+
+The backend now includes a simple resolver capable of fetching
+DID documents from external networks. It bridges to any resolver
+service compatible with the Universal Resolver API, enabling
+cross-chain lookups of identities.

--- a/backend/__tests__/cross_chain_did_resolver.test.js
+++ b/backend/__tests__/cross_chain_did_resolver.test.js
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { CrossChainDIDResolver } from '../src/blockchain/cross_chain_did_resolver.js';
+
+test('resolves DID using external resolver', async () => {
+  const mockDoc = { id: 'did:example:123', '@context': ['https://www.w3.org/ns/did/v1'] };
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({ didDocument: mockDoc })
+  });
+
+  const resolver = new CrossChainDIDResolver('https://mock.resolver');
+  const doc = await resolver.resolve('did:example:123');
+  assert.deepEqual(doc, mockDoc);
+
+  global.fetch = originalFetch;
+});

--- a/backend/src/blockchain/blockchain_integration.js
+++ b/backend/src/blockchain/blockchain_integration.js
@@ -1,0 +1,10 @@
+import { CrossChainDIDResolver } from './cross_chain_did_resolver.js';
+
+/**
+ * resolveDID provides a simple integration point for other parts of the backend
+ * to fetch DID documents from external resolver networks.
+ */
+export async function resolveDID(did, resolverUrl) {
+  const resolver = new CrossChainDIDResolver(resolverUrl);
+  return resolver.resolve(did);
+}

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,0 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform

--- a/backend/src/blockchain/cross_chain_did_resolver.js
+++ b/backend/src/blockchain/cross_chain_did_resolver.js
@@ -1,0 +1,20 @@
+/**
+ * CrossChainDIDResolver fetches DID documents from external resolver services.
+ * The resolverBaseUrl should point to a service compatible with the
+ * Universal Resolver API, e.g. https://uniresolver.io.
+ */
+export class CrossChainDIDResolver {
+  constructor(resolverBaseUrl) {
+    this.resolverBaseUrl = resolverBaseUrl;
+  }
+
+  async resolve(did) {
+    const url = `${this.resolverBaseUrl}/1.0/identifiers/${encodeURIComponent(did)}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch DID document: ${response.status} ${response.statusText}`);
+    }
+    const body = await response.json();
+    return body.didDocument ?? body;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "chai-vc-platform",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chai-vc-platform",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "chai-vc-platform",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test backend/__tests__/cross_chain_did_resolver.test.js"
+  }
+}


### PR DESCRIPTION
## Summary
- implement a cross-chain DID resolver that fetches DID documents from any Universal Resolver compatible service
- expose `resolveDID` helper for backend usage
- document DID resolution capability
- add basic test for resolver
- set up minimal `package.json` for running tests

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687668abd57c8320a72089bd968ed6a8