### PR TITLE
Implement audit scrapbook framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+This demo now includes immutable audit scrapbooks recorded on-chain for every
+major identity action. The `AuditScrapbook` class writes an audit record through
+the `PolkadotService` which would normally commit a transaction containing a hash
+of the activity.

--- a/backend/__tests__/full_end_to_end_test.ts
+++ b/backend/__tests__/full_end_to_end_test.ts
@@ -1,1 +1,6 @@
-// full_end_to_end_test.ts - placeholder or stub for chai-vc-platform
+import { issueCredential } from '../src/controllers/credential_controller';
+
+(async () => {
+    await issueCredential('user123', { id: 'cred1' });
+    console.log('audit scrapbook test executed');
+})();

--- a/backend/src/blockchain/audit_scrapbook.ts
+++ b/backend/src/blockchain/audit_scrapbook.ts
@@ -1,0 +1,14 @@
+import { PolkadotService, AuditRecord } from './polkadot_service';
+
+export class AuditScrapbook {
+    constructor(private polkadot: PolkadotService) {}
+
+    async recordIdentityAction(userId: string, action: string): Promise<void> {
+        const record: AuditRecord = {
+            userId,
+            action,
+            timestamp: Date.now(),
+        };
+        await this.polkadot.storeAuditRecord(record);
+    }
+}

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,13 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+export interface AuditRecord {
+    userId: string;
+    action: string;
+    timestamp: number;
+}
+
+export class PolkadotService {
+    async storeAuditRecord(record: AuditRecord): Promise<void> {
+        // This is a placeholder for the actual interaction with the Polkadot
+        // blockchain which would store a hash of the audit data.
+        console.log('Storing record on-chain:', record);
+    }
+}

--- a/backend/src/controllers/credential_controller.ts
+++ b/backend/src/controllers/credential_controller.ts
@@ -1,1 +1,11 @@
-// credential_controller.ts - placeholder or stub for chai-vc-platform
+import { PolkadotService } from '../blockchain/polkadot_service';
+import { AuditScrapbook } from '../blockchain/audit_scrapbook';
+
+const polkadot = new PolkadotService();
+const scrapbook = new AuditScrapbook(polkadot);
+
+export async function issueCredential(userId: string, credential: any) {
+    // Placeholder for logic that would issue a credential
+    await scrapbook.recordIdentityAction(userId, 'ISSUE_CREDENTIAL');
+    return { userId, credential };
+}


### PR DESCRIPTION
## Summary
- add new `AuditScrapbook` class and `PolkadotService` stub for recording audit data
- integrate audit scrapbook in the credential controller
- update placeholder end-to-end test to use the audit scrapbook
- document immutable audit scrapbooks in README

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: SyntaxError in placeholder test)*
- `npx -y ts-node backend/__tests__/full_end_to_end_test.ts` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_687668b331a883208c5e342493513cea