### PR TITLE
Add multi-token pallet skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Blockchain
+
+This repository contains a basic Substrate pallet implementation to manage
+utilitarian, governance, and reputation tokens. The pallet can be found in
+`backend/src/blockchain/multi_token_pallet.rs` and is intended as a starting
+point for future on-chain logic.

--- a/ai-matcher-service/src/routes/match.py
+++ b/ai-matcher-service/src/routes/match.py
@@ -1,1 +1,1 @@
-// match.py - placeholder or stub for chai-vc-platform
+# match.py - placeholder or stub for chai-vc-platform

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,2 @@
 // blockchain_integration.ts - placeholder or stub for chai-vc-platform
+// This module integrates the custom multi-token pallet written in Rust.

--- a/backend/src/blockchain/multi_token_pallet.rs
+++ b/backend/src/blockchain/multi_token_pallet.rs
@@ -1,0 +1,72 @@
+// multi_token_pallet.rs - simple Substrate pallet skeleton
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
+use frame_system::pallet_prelude::*;
+
+#[derive(Clone, Copy, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+pub enum TokenType {
+    Utilitarian,
+    Governance,
+    Reputation,
+}
+
+#[pallet]
+pub mod pallet {
+    use super::*;
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {}
+
+    #[pallet::pallet]
+    pub struct Pallet<T>(_);
+
+    #[pallet::storage]
+    pub type Balances<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        T::AccountId,
+        Blake2_128Concat,
+        TokenType,
+        u64,
+        ValueQuery,
+    >;
+
+    #[pallet::error]
+    pub enum Error<T> {
+        InsufficientBalance,
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        #[pallet::weight(10_000)]
+        pub fn mint(
+            origin: OriginFor<T>,
+            to: T::AccountId,
+            token: TokenType,
+            amount: u64,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            Balances::<T>::mutate(&to, token, |b| *b += amount);
+            Ok(())
+        }
+
+        #[pallet::weight(10_000)]
+        pub fn transfer(
+            origin: OriginFor<T>,
+            to: T::AccountId,
+            token: TokenType,
+            amount: u64,
+        ) -> DispatchResult {
+            let from = ensure_signed(origin)?;
+            Balances::<T>::try_mutate(&from, token, |balance| -> DispatchResult {
+                ensure!(*balance >= amount, Error::<T>::InsufficientBalance);
+                *balance -= amount;
+                Ok(())
+            })?;
+            Balances::<T>::mutate(&to, token, |b| *b += amount);
+            Ok(())
+        }
+    }
+}

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,2 @@
 // polkadot_service.ts - placeholder or stub for chai-vc-platform
+// Placeholder service that would expose multi-token pallet calls.


### PR DESCRIPTION
## Summary
- implement skeleton Substrate pallet to handle utilitarian, governance and reputation tokens
- reference the pallet from blockchain integration stubs
- document the pallet location in the README
- fix Python placeholder comments for tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68768d85f2208320962c1bfbd120ab18