### PR TITLE
Implement token-based priority queue

### DIFF
--- a/backend/__tests__/token_priority_queue.test.ts
+++ b/backend/__tests__/token_priority_queue.test.ts
@@ -1,0 +1,23 @@
+import assert from 'assert';
+import TokenPriorityQueue, { VerificationRequest } from '../src/queues/token_priority_queue';
+
+const queue = new TokenPriorityQueue();
+
+queue.enqueue({ token: 'low', priority: 1 });
+queue.enqueue({ token: 'high', priority: 10 });
+queue.enqueue({ token: 'medium', priority: 5 });
+
+assert.strictEqual(queue.size(), 3, 'queue should contain 3 items');
+
+const first = queue.dequeue();
+assert.strictEqual(first?.token, 'high', 'highest priority token should dequeue first');
+
+const second = queue.dequeue();
+assert.strictEqual(second?.token, 'medium', 'medium priority token should dequeue second');
+
+const third = queue.dequeue();
+assert.strictEqual(third?.token, 'low', 'lowest priority token should dequeue last');
+
+assert.strictEqual(queue.size(), 0, 'queue should be empty after dequeues');
+
+console.log('TokenPriorityQueue tests passed.');

--- a/backend/src/queues/token_priority_queue.ts
+++ b/backend/src/queues/token_priority_queue.ts
@@ -1,0 +1,39 @@
+export interface VerificationRequest {
+  token: string;
+  priority: number;
+}
+
+/**
+ * TokenPriorityQueue implements a simple priority queue for
+ * verification requests. Higher priority values are processed first.
+ */
+export default class TokenPriorityQueue {
+  private queue: VerificationRequest[] = [];
+
+  /**
+   * Enqueue a new request. The queue is kept sorted in descending
+   * priority so dequeue() always returns the highest priority item.
+   */
+  enqueue(request: VerificationRequest): void {
+    const index = this.queue.findIndex(r => request.priority > r.priority);
+    if (index === -1) {
+      this.queue.push(request);
+    } else {
+      this.queue.splice(index, 0, request);
+    }
+  }
+
+  /**
+   * Remove and return the highest priority request.
+   */
+  dequeue(): VerificationRequest | undefined {
+    return this.queue.shift();
+  }
+
+  /**
+   * Inspect the queue length.
+   */
+  size(): number {
+    return this.queue.length;
+  }
+}


### PR DESCRIPTION
## Summary
- add `TokenPriorityQueue` to manage verification tokens by priority
- create simple tests to validate queue ordering

## Testing
- `npx ts-node --compiler-options '{"module":"CommonJS"}' backend/__tests__/token_priority_queue.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68768db8490083209fda7c51b89255c2