### PR TITLE
Add Chainlink oracle adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+This repository contains a minimal scaffold for the Chai VC platform. The
+backend includes a stubbed `ChainlinkAdapter` for retrieving cross-chain data
+feeds such as license status and risk signals. These adapters are exposed
+through the `BlockchainIntegration` class.

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,15 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+// blockchain_integration.ts - placeholder for overall blockchain integration
+
+import { ChainlinkAdapter } from './oracles/chainlink_adapter';
+
+export class BlockchainIntegration {
+  private chainlink = new ChainlinkAdapter();
+
+  async getLicenseStatus(licenseId: string) {
+    return this.chainlink.fetchLicenseStatus(licenseId);
+  }
+
+  async getRiskSignals(address: string) {
+    return this.chainlink.fetchRiskSignals(address);
+  }
+}

--- a/backend/src/blockchain/oracles/chainlink_adapter.ts
+++ b/backend/src/blockchain/oracles/chainlink_adapter.ts
@@ -1,0 +1,31 @@
+// chainlink_adapter.ts - basic Chainlink oracle integration placeholder
+
+interface LicenseStatusResult {
+  licenseId: string;
+  status: string;
+}
+
+interface RiskSignal {
+  riskScore: number;
+  details: string;
+}
+
+export class ChainlinkAdapter {
+  // Retrieve license status from Chainlink oracle
+  async fetchLicenseStatus(licenseId: string): Promise<LicenseStatusResult> {
+    // Placeholder: in a real implementation this would query a Chainlink data feed
+    return {
+      licenseId,
+      status: 'active',
+    };
+  }
+
+  // Retrieve risk signals for a healthcare provider
+  async fetchRiskSignals(address: string): Promise<RiskSignal> {
+    // Placeholder: in a real implementation this would query a Chainlink data feed
+    return {
+      riskScore: 0,
+      details: 'no known risk',
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add ChainlinkAdapter placeholder for license and risk feed retrieval
- expose ChainlinkAdapter through BlockchainIntegration
- update README with Chainlink oracle info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68768f4bf5c48320bc50011d186d000a