### PR TITLE
Add WebAuthn-OIDC bridge skeleton

### DIFF
--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,4 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+"""Minimal test placeholder for ai-matcher-service."""
+
+def test_placeholder():
+    assert True

--- a/backend/src/auth/README.md
+++ b/backend/src/auth/README.md
@@ -1,0 +1,9 @@
+# WebAuthn/OIDC Bridge
+
+This module contains a minimal skeleton for bridging WebAuthn and
+OpenID Connect (OIDC). It allows a CHAI DID to authenticate through
+WebAuthn and then obtain an OIDC authorization code that can be used in
+standard OAuth2 flows.
+
+The current implementation is highly simplified and serves as a scaffold
+for future development.

--- a/backend/src/auth/webauthn_oidc_bridge.ts
+++ b/backend/src/auth/webauthn_oidc_bridge.ts
@@ -1,0 +1,31 @@
+/**
+ * webauthn_oidc_bridge.ts
+ *
+ * A minimal skeleton for bridging WebAuthn with OIDC.
+ * This allows CHAI decentralized identifiers (DIDs) to
+ * authenticate in OAuth2 flows.
+ */
+
+export interface DIDUser {
+    did: string;
+    publicKey: string;
+}
+
+export class WebAuthnOIDCBridge {
+    constructor() {
+        // Placeholder for initialization such as OIDC provider metadata
+    }
+
+    // Start WebAuthn registration for a DID user
+    startRegistration(user: DIDUser): string {
+        // This is only a stub for demonstration purposes
+        return `Registration challenge for ${user.did}`;
+    }
+
+    // Verify the WebAuthn response and issue an OIDC code
+    verifyAndCreateOIDCCode(webauthnResponse: any): string {
+        // In a real implementation we would validate the response and
+        // generate a signed OAuth2/OIDC authorization code
+        return 'dummy-oidc-code';
+    }
+}


### PR DESCRIPTION
## Summary
- fix Python placeholder test so pytest runs
- add scaffolding for a WebAuthn/OIDC bridge for CHAI DIDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68768f8bfa7083208e4b30552ee0ac14