### PR TITLE
Add Chainlink oracle stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Chainlink Functions Oracle
+
+This repository includes a stub integration with Chainlink Functions to
+demonstrate how off-chain AI logic could provide on-chain risk scores. See
+`backend/src/blockchain/chainlink_oracle.ts` for details.

--- a/ai-matcher-service/src/routes/match.py
+++ b/ai-matcher-service/src/routes/match.py
@@ -1,1 +1,1 @@
-// match.py - placeholder or stub for chai-vc-platform
+# match.py - placeholder or stub for chai-vc-platform

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,1 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform

--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,12 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { queryRiskScore } from './chainlink_oracle';
+
+/**
+ * Example blockchain integration utilities.
+ * The real implementation would interact with smart contracts and oracles.
+ */
+
+export async function getOnChainRisk(userId: string): Promise<number> {
+  // Delegate to the Chainlink Functions oracle integration.
+  return queryRiskScore(userId);
+}
+

--- a/backend/src/blockchain/chainlink_oracle.ts
+++ b/backend/src/blockchain/chainlink_oracle.ts
@@ -1,0 +1,17 @@
+/**
+ * chainlink_oracle.ts
+ *
+ * Stub integration with Chainlink Functions for off-chain AI risk queries.
+ * The real implementation would call Chainlink's network to execute an AI model
+ * and return a risk score that can be used on-chain.
+ */
+
+export async function queryRiskScore(userId: string): Promise<number> {
+  // In production, this function would make a request to a Chainlink Function
+  // that performs the AI risk calculation off-chain. Here we simply log the
+  // invocation and return a mock score.
+  console.log(`Querying Chainlink Functions for risk score of ${userId}`);
+
+  // Placeholder risk score
+  return 42;
+}


### PR DESCRIPTION
## Summary
- add mention of Chainlink oracle integration in README
- use Python comments in match service stubs
- implement Chainlink Functions oracle stub
- export `getOnChainRisk` from blockchain integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765cb0829c8320bf38e6079b9a5a66