### PR TITLE
Add provisional attestation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Provisional Attestations
+
+For issuers that are not yet integrated with the platform, you can issue a provisional attestation. The backend exposes a helper function `offerProvisionalAttestation` which returns a temporary attestation object valid for a configurable number of days.
+
+```typescript
+import { offerProvisionalAttestation } from './backend/src/provisional_attestation';
+
+const attestation = offerProvisionalAttestation('issuer-123');
+```
+
+This allows the platform to acknowledge an issuer while full integration is pending.

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,4 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# Placeholder tests for chai-vc-platform AI matcher service
+
+def test_placeholder():
+    assert True

--- a/backend/__tests__/provisional_attestation.test.ts
+++ b/backend/__tests__/provisional_attestation.test.ts
@@ -1,0 +1,8 @@
+import { offerProvisionalAttestation } from '../src/provisional_attestation';
+
+test('offerProvisionalAttestation returns expected structure', () => {
+  const attestation = offerProvisionalAttestation('issuer-123', 1);
+  expect(attestation.issuerId).toBe('issuer-123');
+  expect(attestation.note).toBe('Provisional attestation for unintegrated issuer');
+  expect(attestation.expiresAt.getTime()).toBeGreaterThan(attestation.issuedAt.getTime());
+});

--- a/backend/src/provisional_attestation.ts
+++ b/backend/src/provisional_attestation.ts
@@ -1,0 +1,16 @@
+export interface ProvisionalAttestation {
+  issuerId: string;
+  issuedAt: Date;
+  expiresAt: Date;
+  note: string;
+}
+
+export function offerProvisionalAttestation(
+  issuerId: string,
+  daysValid: number = 30,
+  note: string = 'Provisional attestation for unintegrated issuer'
+): ProvisionalAttestation {
+  const issuedAt = new Date();
+  const expiresAt = new Date(issuedAt.getTime() + daysValid * 24 * 60 * 60 * 1000);
+  return { issuerId, issuedAt, expiresAt, note };
+}


### PR DESCRIPTION
## Summary
- add helper for provisional attestation
- show how to issue provisional attestation in README
- add backend test for provisional attestation
- fix placeholder Python test

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686d8a85e8f083208656ec082ba1e494