### PR TITLE
Add status-only sharing toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Chai VC Platform
 
 End-to-end healthcare credentialing and hiring verification.
+
+## Wallet UX
+
+The demonstration wallet now includes a **Share only status** toggle on the
+credential details page. Enabling this option shares a simple proof that the
+credential exists and is valid instead of exposing the entire verifiable
+credential payload. The proof generation is stubbed in the frontend but serves
+as a placeholder for future cryptographic implementations.

--- a/ai-matcher-service/src/routes/match.py
+++ b/ai-matcher-service/src/routes/match.py
@@ -1,1 +1,16 @@
-// match.py - placeholder or stub for chai-vc-platform
+# match.py - placeholder or stub for chai-vc-platform
+
+"""Placeholder module for route handlers.
+
+This module simulates a minimal API endpoint used by tests. It does not
+implement any real logic but provides a function signature that can be
+imported without syntax errors. Keeping the file valid Python ensures that
+the project's test suite runs cleanly.
+"""
+
+
+def dummy_match(data: dict) -> dict:
+    """Return a dummy match result for the provided data."""
+
+    return {"matched": False, "input": data}
+

--- a/ai-matcher-service/tests/test_matcher.py
+++ b/ai-matcher-service/tests/test_matcher.py
@@ -1,1 +1,16 @@
-// test_matcher.py - placeholder or stub for chai-vc-platform
+# test_matcher.py - placeholder or stub for chai-vc-platform
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from routes.match import dummy_match
+
+
+def test_dummy_match():
+    """Verify that the dummy_match function returns the expected structure."""
+
+    result = dummy_match({"foo": "bar"})
+    assert result == {"matched": False, "input": {"foo": "bar"}}
+

--- a/frontend/pages/credentials/[id].tsx
+++ b/frontend/pages/credentials/[id].tsx
@@ -1,1 +1,49 @@
-// [id].tsx - placeholder or stub for chai-vc-platform
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+/**
+ * Credential detail page.
+ *
+ * This minimalist implementation demonstrates a "share only status" toggle.
+ * When enabled, the user shares a proof of credential status instead of the
+ * entire verifiable credential (VC).
+ */
+export default function CredentialDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [shareStatusOnly, setShareStatusOnly] = useState(false);
+  const [shareOutput, setShareOutput] = useState<string | null>(null);
+
+  function generateStatusProof(vcId: string | string[] | undefined) {
+    // Placeholder: real implementation would produce a cryptographic proof.
+    return `Proof of status for VC ${vcId}`;
+  }
+
+  function generateFullVC(vcId: string | string[] | undefined) {
+    // Placeholder representing the full credential payload.
+    return `Full VC data for ${vcId}`;
+  }
+
+  function handleShare() {
+    const output = shareStatusOnly ? generateStatusProof(id) : generateFullVC(id);
+    setShareOutput(output);
+  }
+
+  return (
+    <div>
+      <h1>Credential {id}</h1>
+      <label>
+        <input
+          type="checkbox"
+          checked={shareStatusOnly}
+          onChange={(e) => setShareStatusOnly(e.target.checked)}
+        />
+        Share only status
+      </label>
+      <button onClick={handleShare}>Share</button>
+      {shareOutput && (
+        <pre data-testid="share-output">{shareOutput}</pre>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement simple wallet credential page with a "Share only status" checkbox
- generate dummy proof when checkbox is enabled
- create stub Python module and test so that `pytest` runs
- document the wallet UX in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4527a2508320901142f31ff4c737