### PR TITLE
docs(ops): add runbook and incident templates

### DIFF
--- a/docs/incident-comms-template.md
+++ b/docs/incident-comms-template.md
@@ -1,0 +1,27 @@
+# Incident Communication Templates
+
+## Initial Alert
+```
+Subject: [SEV-<level>] <system> issue detected
+Time: <UTC>
+Impact: <summary>
+Actions Underway: <teams>
+Next Update: <time>
+```
+
+## Status Update
+```
+Subject: [SEV-<level>] Update <n>
+Time: <UTC>
+Status: <investigation/mitigation>
+ETA: <resolution estimate>
+```
+
+## Resolution
+```
+Subject: [SEV-<level>] Resolved
+Time: <UTC>
+Root Cause: <summary>
+Customer Impact: <summary>
+Follow-up: <ticket/PR links>
+```

--- a/docs/on-call-template.md
+++ b/docs/on-call-template.md
@@ -1,0 +1,11 @@
+# On‑Call Schedule Template
+
+| Week | Primary | Secondary | Notes |
+|------|---------|-----------|-------|
+| 1    | <name>  | <name>    |       |
+| 2    | <name>  | <name>    |       |
+
+## Responsibilities
+- Acknowledge alerts within 5 minutes.
+- Provide status updates every 30 minutes during an incident.
+- Ensure handoff notes cover outstanding actions and log links.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,19 @@
+# Operations Runbook
+
+## Overview
+Guides on maintaining service health and responding to incidents across the CHAI credentialing platform.
+
+## Health Checks
+- **Liveness**: `GET /healthz`
+- **Readiness**: `GET /readyz`
+- **Key Dashboards**: `issuer_latency_ms`, `verify_fail_rate`
+
+## Incident Response
+1. **Detect**: Pager alert or dashboard anomaly.
+2. **Triage**: Classify severity, assign incident commander.
+3. **Mitigate**: Apply known fixes or rollback via `scripts/dr/failover.sh`.
+4. **Communicate**: Use the incident comms templates in `incident-comms-template.md`.
+5. **Post‑mortem**: Capture timeline and corrective actions within 48h.
+
+## Acceptance
+Tabletop incident exercise passes.


### PR DESCRIPTION
## Summary
- add operations runbook with health checks and incident steps
- provide on-call rotation template and incident comms templates

## Testing
- `npm test` *(fails: Plugin @nomicfoundation/hardhat-toolbox requires dependencies)*
- `pytest` *(fails: backend/tests/test_trace_propagation.py::test_trace_id_propagation - assert 0 == 4)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68b2beb97c108320ada6c2054f84d0ea)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces foundational ops documentation to standardize incident handling and on‑call practices.
> 
> - Adds `docs/runbook.md` with health checks (`GET /healthz`, `GET /readyz`), key dashboards (`issuer_latency_ms`, `verify_fail_rate`), and incident response steps including rollback via `scripts/dr/failover.sh`
> - Adds `docs/incident-comms-template.md` with templates for initial alerts, status updates, and resolution communications
> - Adds `docs/on-call-template.md` defining weekly rotation table and on‑call responsibilities
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 099e386b011d69fc3fecec35cc64ba8eb434e068. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->