### PR TITLE
feat(perf): add locust perf test for credential flows

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,18 @@
+# Performance Testing
+
+This suite uses [Locust](https://locust.io) to exercise the credential issuance and verification flows.
+
+## Run
+
+1. Start the backend server:
+   ```bash
+   cd backend
+   npm install
+   npm start
+   ```
+2. In another terminal, run Locust in headless mode at the desired load:
+   ```bash
+   locust -f perf/locustfile.py --headless -u 50 -r 10 -t 1m --host http://localhost:4000
+   ```
+
+The test will issue, verify and present credentials. It fails if the p95 latency of the `verify` step exceeds **250ms**.

--- a/perf/locustfile.py
+++ b/perf/locustfile.py
@@ -1,0 +1,40 @@
+from locust import HttpUser, task, between, events
+
+class CredentialUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+
+    def on_start(self):
+        self.credential_id = None
+
+    @task
+    def issue_verify_present(self):
+        issue_payload = {
+            "query": "mutation($name:String!,$issuer:String!){createCredential(name:$name,issuer:$issuer){id}}",
+            "variables": {"name": "PerfTest", "issuer": "PerfIssuer"}
+        }
+        with self.client.post("/graphql", json=issue_payload, name="issue", catch_response=True) as resp:
+            if resp.status_code == 200:
+                try:
+                    self.credential_id = resp.json()["data"]["createCredential"]["id"]
+                except Exception:
+                    resp.failure("bad issue response")
+            else:
+                resp.failure(f"issue failed {resp.status_code}")
+
+        if self.credential_id:
+            verify_payload = {
+                "query": "query($id:ID!){credential(id:$id){id}}",
+                "variables": {"id": self.credential_id}
+            }
+            self.client.post("/graphql", json=verify_payload, name="verify")
+
+            present_payload = {"query": "query{credentials{id}}"}
+            self.client.post("/graphql", json=present_payload, name="present")
+
+
+@events.quitting.add_listener
+def _(environment, **_kwargs):
+    stats = environment.stats.get("verify", "POST")
+    if stats and stats.get_response_time_percentile(0.95) > 250:
+        print("Verify p95 >250ms")
+        environment.process_exit_code = 1


### PR DESCRIPTION
## Summary
- add Locust load test for issuing, verifying and presenting credentials
- document how to run performance suite

## Testing
- `locust -f perf/locustfile.py --headless -u 1 -r 1 -t 2s --host http://localhost:4000` *(fails: connection refused)*
- `npm test` *(fails: npm error canceled)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68b2be4939fc83208d0ebee6d12aa71b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a Locust-based performance suite for credential flows.
> 
> - Adds `perf/locustfile.py` to load test GraphQL `issue` (create), `verify`, and `present` steps against `/graphql`
> - Enforces SLO: exits non-zero if `verify` p95 latency exceeds `250ms` via `events.quitting` check
> - Documents setup and headless run commands in `perf/README.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddc6bfce96219f193c3a00388a4a4c7a6ac5e6db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->