### PR TITLE
feat(wallet): secure keystore with biometric unlock

### DIFF
--- a/wallet/App.tsx
+++ b/wallet/App.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { View, Button, Text, StyleSheet } from 'react-native';
+import { generateAndStoreKey, getKeyWithBiometrics } from './src/keyManager';
+
+export default function App() {
+  const [stored, setStored] = useState(false);
+  const [key, setKey] = useState<string | null>(null);
+
+  return (
+    <View style={styles.container}>
+      <Button
+        testID="generate-key"
+        title="Generate Key"
+        onPress={async () => {
+          await generateAndStoreKey();
+          setStored(true);
+        }}
+      />
+      {stored && <Text testID="key-generated">Key stored securely.</Text>}
+      <Button
+        testID="unlock-key"
+        title="Unlock"
+        onPress={async () => {
+          const k = await getKeyWithBiometrics();
+          setKey(k);
+        }}
+      />
+      {key && <Text testID="key-value">{key}</Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' }
+});

--- a/wallet/__mocks__/expo-crypto.ts
+++ b/wallet/__mocks__/expo-crypto.ts
@@ -1,0 +1,1 @@
+export const getRandomBytes = jest.fn((length: number) => new Uint8Array(length).fill(1));

--- a/wallet/__mocks__/expo-local-authentication.ts
+++ b/wallet/__mocks__/expo-local-authentication.ts
@@ -1,0 +1,1 @@
+export const authenticateAsync = jest.fn(async () => ({ success: true }));

--- a/wallet/__mocks__/expo-secure-store.ts
+++ b/wallet/__mocks__/expo-secure-store.ts
@@ -1,0 +1,2 @@
+export const setItemAsync = jest.fn(async () => undefined);
+export const getItemAsync = jest.fn(async () => null);

--- a/wallet/__tests__/keyManager.test.ts
+++ b/wallet/__tests__/keyManager.test.ts
@@ -1,0 +1,36 @@
+import { generateAndStoreKey, getKeyWithBiometrics, keyExists } from '../src/keyManager';
+import * as SecureStore from 'expo-secure-store';
+import * as LocalAuthentication from 'expo-local-authentication';
+
+describe('key manager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('generates and stores a 32-byte hex key', async () => {
+    (SecureStore.setItemAsync as jest.Mock).mockResolvedValueOnce(undefined);
+    const key = await generateAndStoreKey();
+    expect(key).toHaveLength(64);
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('wallet_key', key);
+  });
+
+  test('retrieves key after successful biometric auth', async () => {
+    (LocalAuthentication.authenticateAsync as jest.Mock).mockResolvedValueOnce({ success: true });
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce('abcd');
+    const key = await getKeyWithBiometrics();
+    expect(key).toBe('abcd');
+    expect(LocalAuthentication.authenticateAsync).toHaveBeenCalled();
+  });
+
+  test('throws when biometric auth fails', async () => {
+    (LocalAuthentication.authenticateAsync as jest.Mock).mockResolvedValueOnce({ success: false });
+    await expect(getKeyWithBiometrics()).rejects.toThrow('Authentication failed');
+  });
+
+  test('keyExists reflects presence', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(null);
+    expect(await keyExists()).toBe(false);
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce('abcd');
+    expect(await keyExists()).toBe(true);
+  });
+});

--- a/wallet/detox.config.js
+++ b/wallet/detox.config.js
@@ -1,0 +1,34 @@
+module.exports = {
+  testRunner: 'jest',
+  runnerConfig: 'e2e/jest.config.js',
+  apps: {
+    'ios.debug': {
+      type: 'ios.app',
+      binaryPath: 'bin/ios/ExpoGo.app'
+    },
+    'android.debug': {
+      type: 'android.apk',
+      binaryPath: 'bin/android/ExpoGo.apk'
+    }
+  },
+  devices: {
+    simulator: {
+      type: 'ios.simulator',
+      device: { type: 'iPhone 14' }
+    },
+    emulator: {
+      type: 'android.emulator',
+      device: { avdName: 'Pixel_3a_API_30_x86' }
+    }
+  },
+  configurations: {
+    'ios.debug': {
+      device: 'simulator',
+      app: 'ios.debug'
+    },
+    'android.debug': {
+      device: 'emulator',
+      app: 'android.debug'
+    }
+  }
+};

--- a/wallet/e2e/jest.config.js
+++ b/wallet/e2e/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testTimeout: 120000,
+};

--- a/wallet/e2e/keyflow.e2e.ts
+++ b/wallet/e2e/keyflow.e2e.ts
@@ -1,0 +1,15 @@
+// Detox end-to-end test placeholder for iOS and Android
+// Requires Expo Go binaries and device configuration.
+
+describe('wallet key flow', () => {
+  beforeAll(async () => {
+    await device.launchApp();
+  });
+
+  it('generates and unlocks key', async () => {
+    await element(by.id('generate-key')).tap();
+    await expect(element(by.id('key-generated'))).toBeVisible();
+    await element(by.id('unlock-key')).tap();
+    await expect(element(by.id('key-value'))).toBeVisible();
+  });
+});

--- a/wallet/jest.config.js
+++ b/wallet/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^expo-secure-store$': '<rootDir>/__mocks__/expo-secure-store.ts',
+    '^expo-local-authentication$': '<rootDir>/__mocks__/expo-local-authentication.ts',
+    '^expo-crypto$': '<rootDir>/__mocks__/expo-crypto.ts'
+  }
+};

--- a/wallet/package.json
+++ b/wallet/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "wallet-core",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.tsx",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.6",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/wallet/src/keyManager.ts
+++ b/wallet/src/keyManager.ts
@@ -1,0 +1,31 @@
+import * as SecureStore from 'expo-secure-store';
+import * as LocalAuthentication from 'expo-local-authentication';
+import { getRandomBytes } from 'expo-crypto';
+
+const KEY_NAME = 'wallet_key';
+
+export async function generateAndStoreKey(): Promise<string> {
+  const bytes = getRandomBytes(32);
+  const key = Buffer.from(bytes).toString('hex');
+  await SecureStore.setItemAsync(KEY_NAME, key);
+  return key;
+}
+
+export async function getKeyWithBiometrics(): Promise<string> {
+  const result = await LocalAuthentication.authenticateAsync({
+    promptMessage: 'Authenticate to unlock wallet'
+  });
+  if (!result.success) {
+    throw new Error('Authentication failed');
+  }
+  const key = await SecureStore.getItemAsync(KEY_NAME);
+  if (!key) {
+    throw new Error('No key found');
+  }
+  return key;
+}
+
+export async function keyExists(): Promise<boolean> {
+  const key = await SecureStore.getItemAsync(KEY_NAME);
+  return key !== null;
+}

--- a/wallet/tsconfig.json
+++ b/wallet/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": [
+    "src/**/*",
+    "__tests__/**/*",
+    "types/**/*"
+  ]
+}

--- a/wallet/types/expo-modules.d.ts
+++ b/wallet/types/expo-modules.d.ts
@@ -1,0 +1,3 @@
+declare module 'expo-secure-store';
+declare module 'expo-local-authentication';
+declare module 'expo-crypto';


### PR DESCRIPTION
## Summary
- add Expo key manager storing keys in device SecureStore
- gate key retrieval behind biometric authentication
- scaffold Detox E2E flow for iOS/Android

## Testing
- `cd wallet && npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68b273382fd883208fc16b1c0c1414e6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces secure key management and test scaffolding for the wallet app.
> 
> - Adds `src/keyManager.ts` to generate a 32-byte hex key, store in `SecureStore`, retrieve behind `LocalAuthentication`, and expose `keyExists`
> - Minimal React Native `App.tsx` to trigger key generation/unlock via buttons with testIDs
> - Jest unit tests for key flows with mocks for `expo-secure-store`, `expo-local-authentication`, and `expo-crypto`; Jest/TS configs and module declarations
> - Detox configuration and basic E2E test placeholder for iOS/Android to verify generate/unlock flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b940dacfffcb868c99078b9ca53784e7af3d992d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->