### PR TITLE
feat: add cross-chain dao governance contract

### DIFF
--- a/backend/src/blockchain/blockchain_integration.ts
+++ b/backend/src/blockchain/blockchain_integration.ts
@@ -1,1 +1,66 @@
-// blockchain_integration.ts - placeholder or stub for chai-vc-platform
+import { ethers } from "ethers";
+
+// Minimal ABI and bytecode placeholders for the CrossChainDAO contract.
+const CrossChainDAOAbi = [
+  "function propose(string description, uint256 votingPeriod) public returns (uint256)",
+  "function vote(uint256 proposalId, bool support) public",
+  "function receiveCrossChainVote(uint256 proposalId, address voter, bool support, uint256 weight, string sourceChain) public"
+];
+// In a real deployment this would be the compiled bytecode output by the Solidity compiler.
+const CrossChainDAOBytecode = "0x";
+
+/**
+ * Simple wrapper around the CrossChainDAO smart contract using ethers.js.
+ * Provides helpers to deploy the contract and interact with governance features.
+ */
+export class BlockchainIntegration {
+  private provider: ethers.providers.JsonRpcProvider;
+  private wallet: ethers.Wallet;
+  public contract?: ethers.Contract;
+
+  constructor(rpcUrl: string, privateKey: string, contractAddress?: string) {
+    this.provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+    this.wallet = new ethers.Wallet(privateKey, this.provider);
+    if (contractAddress) {
+      this.contract = new ethers.Contract(contractAddress, CrossChainDAOAbi, this.wallet);
+    }
+  }
+
+  /** Deploy a new DAO instance and store the connected contract. */
+  async deployDAO(): Promise<string> {
+    const factory = new ethers.ContractFactory(CrossChainDAOAbi, CrossChainDAOBytecode, this.wallet);
+    const contract = await factory.deploy(this.wallet.address);
+    await contract.deployed();
+    this.contract = contract;
+    return contract.address;
+  }
+
+  /** Create a proposal describing an off-chain governance action. */
+  async propose(description: string, votingPeriod: number): Promise<ethers.ContractTransactionReceipt> {
+    if (!this.contract) throw new Error("Contract not initialised");
+    const tx = await this.contract.propose(description, votingPeriod);
+    return tx.wait();
+  }
+
+  /** Cast a vote for or against a proposal. */
+  async vote(proposalId: number, support: boolean): Promise<ethers.ContractTransactionReceipt> {
+    if (!this.contract) throw new Error("Contract not initialised");
+    const tx = await this.contract.vote(proposalId, support);
+    return tx.wait();
+  }
+
+  /** Relay a vote from a different chain into the DAO. */
+  async receiveCrossChainVote(
+    proposalId: number,
+    voter: string,
+    support: boolean,
+    weight: number,
+    sourceChain: string
+  ): Promise<ethers.ContractTransactionReceipt> {
+    if (!this.contract) throw new Error("Contract not initialised");
+    const tx = await this.contract.receiveCrossChainVote(proposalId, voter, support, weight, sourceChain);
+    return tx.wait();
+  }
+}
+
+export default BlockchainIntegration;

--- a/backend/src/blockchain/contracts/CrossChainDAO.sol
+++ b/backend/src/blockchain/contracts/CrossChainDAO.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+
+/// @title CrossChainDAO
+/// @notice Simple governance contract allowing issuers, holders and verifiers to vote on proposals.
+/// @dev Includes a hook for cross-chain vote relays through the BRIDGE_ROLE.
+contract CrossChainDAO is AccessControl {
+    bytes32 public constant ISSUER_ROLE = keccak256("ISSUER_ROLE");
+    bytes32 public constant HOLDER_ROLE = keccak256("HOLDER_ROLE");
+    bytes32 public constant VERIFIER_ROLE = keccak256("VERIFIER_ROLE");
+    bytes32 public constant BRIDGE_ROLE = keccak256("BRIDGE_ROLE");
+
+    struct Proposal {
+        string description;      // human readable description
+        uint256 forVotes;        // count of supporting votes
+        uint256 againstVotes;    // count of opposing votes
+        bool executed;           // whether proposal has been executed
+        uint256 deadline;        // timestamp when voting ends
+    }
+
+    // Mapping of proposal id to proposal data
+    mapping(uint256 => Proposal) public proposals;
+    // Tracks which addresses have voted on a proposal
+    mapping(uint256 => mapping(address => bool)) public hasVoted;
+    // Total number of proposals created
+    uint256 public proposalCount;
+
+    event ProposalCreated(uint256 indexed id, string description, uint256 deadline);
+    event Voted(uint256 indexed proposalId, address indexed voter, bool support, uint256 weight);
+    event CrossChainVote(uint256 indexed proposalId, address indexed voter, bool support, uint256 weight, string sourceChain);
+    event ProposalExecuted(uint256 indexed proposalId);
+
+    constructor(address admin) {
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    }
+
+    /// @notice Create a new proposal.
+    /// @param description Text describing the proposal.
+    /// @param votingPeriod Duration in seconds that voting remains open.
+    /// @return proposalId Identifier of the created proposal.
+    function propose(string memory description, uint256 votingPeriod) public returns (uint256 proposalId) {
+        require(
+            hasRole(ISSUER_ROLE, msg.sender) ||
+            hasRole(HOLDER_ROLE, msg.sender) ||
+            hasRole(VERIFIER_ROLE, msg.sender),
+            "Unauthorized proposer"
+        );
+
+        proposalId = ++proposalCount;
+        Proposal storage p = proposals[proposalId];
+        p.description = description;
+        p.deadline = block.timestamp + votingPeriod;
+
+        emit ProposalCreated(proposalId, description, p.deadline);
+    }
+
+    /// @notice Cast a local vote on a proposal.
+    /// @param proposalId Identifier of the proposal.
+    /// @param support True to vote in favour, false to vote against.
+    function vote(uint256 proposalId, bool support) public {
+        Proposal storage p = proposals[proposalId];
+        require(block.timestamp < p.deadline, "Voting closed");
+        require(
+            hasRole(ISSUER_ROLE, msg.sender) ||
+            hasRole(HOLDER_ROLE, msg.sender) ||
+            hasRole(VERIFIER_ROLE, msg.sender),
+            "Unauthorized voter"
+        );
+        require(!hasVoted[proposalId][msg.sender], "Already voted");
+
+        hasVoted[proposalId][msg.sender] = true;
+        uint256 weight = _getWeight(msg.sender);
+        if (support) {
+            p.forVotes += weight;
+        } else {
+            p.againstVotes += weight;
+        }
+
+        emit Voted(proposalId, msg.sender, support, weight);
+    }
+
+    /// @notice Record a vote that originated on another chain.
+    /// @dev Only callable by an account with the BRIDGE_ROLE that represents the cross-chain bridge.
+    /// @param proposalId Identifier of the proposal.
+    /// @param voter Address of the original voter on the remote chain.
+    /// @param support True to vote in favour, false to vote against.
+    /// @param weight Voting weight assigned to the voter on the remote chain.
+    /// @param sourceChain Name or identifier of the source chain.
+    function receiveCrossChainVote(
+        uint256 proposalId,
+        address voter,
+        bool support,
+        uint256 weight,
+        string memory sourceChain
+    )
+        public
+    {
+        Proposal storage p = proposals[proposalId];
+        require(hasRole(BRIDGE_ROLE, msg.sender), "Only bridge");
+        require(block.timestamp < p.deadline, "Voting closed");
+        require(!hasVoted[proposalId][voter], "Already voted");
+
+        hasVoted[proposalId][voter] = true;
+        if (support) {
+            p.forVotes += weight;
+        } else {
+            p.againstVotes += weight;
+        }
+
+        emit CrossChainVote(proposalId, voter, support, weight, sourceChain);
+    }
+
+    /// @notice Execute a proposal after voting has concluded and passed.
+    /// @param proposalId Identifier of the proposal.
+    function execute(uint256 proposalId) public {
+        Proposal storage p = proposals[proposalId];
+        require(block.timestamp >= p.deadline, "Voting not closed");
+        require(!p.executed, "Already executed");
+        require(p.forVotes > p.againstVotes, "Proposal not approved");
+
+        p.executed = true;
+        emit ProposalExecuted(proposalId);
+        // In a full implementation, governance actions would occur here.
+    }
+
+    /// @dev Determine the voting weight for a voter. Currently each address gets one vote.
+    function _getWeight(address /*voter*/) internal pure returns (uint256) {
+        return 1;
+    }
+}
+

--- a/backend/src/blockchain/polkadot_service.ts
+++ b/backend/src/blockchain/polkadot_service.ts
@@ -1,1 +1,34 @@
-// polkadot_service.ts - placeholder or stub for chai-vc-platform
+import { ApiPromise, WsProvider } from "@polkadot/api";
+
+/**
+ * Lightweight wrapper around the Polkadot API used to relay votes between chains.
+ * The implementation focuses on connectivity and a stub for cross-chain messaging.
+ */
+export class PolkadotService {
+  private api?: ApiPromise;
+
+  /** Connect to a Polkadot endpoint. */
+  async connect(endpoint: string): Promise<void> {
+    const provider = new WsProvider(endpoint);
+    this.api = await ApiPromise.create({ provider });
+  }
+
+  /** Disconnect the current API instance. */
+  async disconnect(): Promise<void> {
+    await this.api?.disconnect();
+    this.api = undefined;
+  }
+
+  /**
+   * Placeholder to demonstrate sending a cross-chain vote message.
+   * In a production system this would build and submit an XCM transaction
+   * carrying the vote data to another chain.
+   */
+  async sendCrossChainVote(targetContract: string, payload: unknown): Promise<void> {
+    if (!this.api) throw new Error("Not connected to a Polkadot node");
+    // Real implementation would submit an extrinsic here. For now we just log.
+    console.log(`Sending cross-chain vote to ${targetContract}`, payload);
+  }
+}
+
+export default new PolkadotService();


### PR DESCRIPTION
## Summary
- add CrossChainDAO smart contract with roles for issuers, holders, verifiers and cross-chain vote relay
- provide ethers.js integration utilities for deploying and interacting with DAO
- implement Polkadot service stub for sending cross-chain vote messages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68943a2e1ba083209dc82a86e3cc3db5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a minimal cross-chain governance stack with on-chain voting and cross-chain vote relay hooks.
> 
> - New Solidity `CrossChainDAO` contract with roles (`ISSUER_ROLE`, `HOLDER_ROLE`, `VERIFIER_ROLE`, `BRIDGE_ROLE`), proposal lifecycle (`propose`, `vote`, `receiveCrossChainVote`, `execute`), and events
> - Ethers.js wrapper `backend/src/blockchain/blockchain_integration.ts` to deploy the DAO and call `propose`, `vote`, and `receiveCrossChainVote` (uses minimal ABI/bytecode placeholders)
> - Polkadot connectivity stub `backend/src/blockchain/polkadot_service.ts` to `connect`/`disconnect` and placeholder `sendCrossChainVote` for future XCM-based relays
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e3f1a0168bbcc2baafe3f3f376c9fce601b6469. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->