### PR TITLE
feat: add soulbound token selective disclosure

### DIFF
--- a/backend/__tests__/soulbound_token.test.ts
+++ b/backend/__tests__/soulbound_token.test.ts
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import { SoulboundToken } from '../src/blockchain/soulbound_token';
+
+const attributes = {
+  name: 'Alice',
+  age: '30',
+  country: 'Wonderland',
+};
+
+const token = new SoulboundToken(attributes);
+const disclosure = token.generateDisclosure('age');
+
+// Should verify correctly for the disclosed attribute
+assert(
+  SoulboundToken.verifyDisclosure(token.root, 'age', disclosure.value, disclosure.proof),
+  'Valid disclosure should verify',
+);
+
+// Verification should fail for incorrect value
+assert(
+  !SoulboundToken.verifyDisclosure(token.root, 'age', '31', disclosure.proof),
+  'Incorrect attribute value should not verify',
+);
+
+console.log('Selective disclosure test passed');

--- a/backend/src/blockchain/soulbound_token.ts
+++ b/backend/src/blockchain/soulbound_token.ts
@@ -1,0 +1,99 @@
+import crypto from 'crypto';
+
+export type Attributes = Record<string, string>;
+
+export interface ProofStep {
+  sibling: string;
+  isLeft: boolean;
+}
+
+function hash(data: string): string {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+class MerkleTree {
+  private leaves: string[];
+  private layers: string[][];
+  private indexMap: Map<string, number>;
+
+  constructor(attributes: Attributes) {
+    const entries = Object.entries(attributes);
+    this.leaves = entries.map(([k, v]) => hash(`${k}:${v}`));
+    this.indexMap = new Map(entries.map(([k, v], i) => [`${k}:${v}`, i]));
+    this.layers = [this.leaves];
+
+    while (this.layers[this.layers.length - 1].length > 1) {
+      const prev = this.layers[this.layers.length - 1];
+      const next: string[] = [];
+      for (let i = 0; i < prev.length; i += 2) {
+        const left = prev[i];
+        const right = prev[i + 1] ?? prev[i];
+        next.push(hash(left + right));
+      }
+      this.layers.push(next);
+    }
+  }
+
+  root(): string {
+    return this.layers[this.layers.length - 1][0] || '';
+  }
+
+  proof(name: string, value: string): ProofStep[] {
+    const key = `${name}:${value}`;
+    const startIndex = this.indexMap.get(key);
+    if (startIndex === undefined) {
+      throw new Error('Attribute not found');
+    }
+    let index = startIndex;
+    const proof: ProofStep[] = [];
+    for (let layer = 0; layer < this.layers.length - 1; layer++) {
+      const currentLayer = this.layers[layer];
+      const isRightNode = index % 2 === 1;
+      const pairIndex = isRightNode ? index - 1 : index + 1;
+      const sibling = currentLayer[pairIndex] ?? currentLayer[index];
+      proof.push({ sibling, isLeft: isRightNode });
+      index = Math.floor(index / 2);
+    }
+    return proof;
+  }
+}
+
+export class SoulboundToken {
+  private attributes: Attributes;
+  private tree: MerkleTree;
+  public readonly root: string;
+
+  constructor(attributes: Attributes) {
+    this.attributes = attributes;
+    this.tree = new MerkleTree(attributes);
+    this.root = this.tree.root();
+  }
+
+  generateDisclosure(attribute: string): { value: string; proof: ProofStep[] } {
+    const value = this.attributes[attribute];
+    if (value === undefined) {
+      throw new Error('Unknown attribute');
+    }
+    const proof = this.tree.proof(attribute, value);
+    return { value, proof };
+  }
+
+  static verifyDisclosure(
+    root: string,
+    attribute: string,
+    value: string,
+    proof: ProofStep[]
+  ): boolean {
+    let computed = hash(`${attribute}:${value}`);
+    for (const step of proof) {
+      if (step.isLeft) {
+        computed = hash(step.sibling + computed);
+      } else {
+        computed = hash(computed + step.sibling);
+      }
+    }
+    return computed === root;
+  }
+}
+
+export default SoulboundToken;


### PR DESCRIPTION
## Summary
- implement soulbound token with Merkle-tree based selective disclosure proofs
- add tests demonstrating attribute proof generation and verification

## Testing
- `npx ts-node --transpile-only --compiler-options '{"module":"commonjs"}' backend/__tests__/soulbound_token.test.ts`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68943953985483209b290435a44073e6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements selective attribute disclosure for soulbound tokens using Merkle proofs.
> 
> - New `backend/src/blockchain/soulbound_token.ts` with `SoulboundToken`, internal `MerkleTree`, `ProofStep`, and `verifyDisclosure`/`generateDisclosure` APIs
> - Unit test `backend/__tests__/soulbound_token.test.ts` covers valid proof verification and rejection of incorrect values
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d81e022ecbfec9c7e119143caf097bec9d038915. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->